### PR TITLE
Fix flaky test testRetryTimeoutExceeds

### DIFF
--- a/tests/ApiCallableTest.php
+++ b/tests/ApiCallableTest.php
@@ -175,9 +175,17 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
             $backoffSettings);
         $callSettings = new CallSettings(['retrySettings' => $retrySettings]);
 
+        // Use time function that simulates 1100ms elapsing with each call to the stub
+        $incrementMillis = 1100;
+        $timeFuncMillis = function() use ($stub, $incrementMillis) {
+            $actualCalls = count($stub->actualCalls);
+            return $actualCalls * $incrementMillis;
+        };
+
         $raisedException = null;
         try {
-            $apiCall = ApiCallable::createApiCall($stub, 'takeAction', $callSettings);
+            $apiCall = ApiCallable::createApiCall(
+                $stub, 'takeAction', $callSettings, ['timeFuncMillis' => $timeFuncMillis]);
             $response = $apiCall($request, [], []);
         } catch (Google\GAX\ApiException $e) {
             $raisedException = $e;


### PR DESCRIPTION
Fix flaky test testRetryTimeoutExceeds using deterministic function to get elapsed time instead of relying on system clock.