### PR TITLE
Update agent header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
   - '5.5.38'
-  - '5.6'
+  - '5.6.25'
 sudo: required
 dist: trusty
 install:

--- a/src/AgentHeaderDescriptor.php
+++ b/src/AgentHeaderDescriptor.php
@@ -75,9 +75,9 @@ class AgentHeaderDescriptor
      */
     public function getHeader()
     {
-        return [self::AGENT_HEADER_KEY => "$this->clientName/$this->clientVersion;".
+        return [self::AGENT_HEADER_KEY => ["$this->clientName/$this->clientVersion;".
             "$this->codeGenName/$this->codeGenVersion;gax/$this->gaxVersion;".
-            "php/$this->phpVersion"];
+            "php/$this->phpVersion"]];
     }
 
     private static function validate($descriptor)

--- a/src/AgentHeaderDescriptor.php
+++ b/src/AgentHeaderDescriptor.php
@@ -39,7 +39,7 @@ use InvalidArgumentException;
  */
 class AgentHeaderDescriptor
 {
-    const AGENT_HEADER_KEY = 'x-google-apis-agent';
+    const AGENT_HEADER_KEY = 'x-goog-api-client';
 
     private $clientName;
     private $clientVersion;

--- a/src/ApiCallable.php
+++ b/src/ApiCallable.php
@@ -152,7 +152,6 @@ class ApiCallable
     public static function createApiCall($stub, $methodName, CallSettings $settings, $options = [])
     {
         $apiCall = function () use ($stub, $methodName) {
-
             list($response, $status) =
                 call_user_func_array(array($stub, $methodName), func_get_args())->wait();
             if ($status->code == Grpc\STATUS_OK) {

--- a/src/ApiCallable.php
+++ b/src/ApiCallable.php
@@ -130,10 +130,7 @@ class ApiCallable
             } else {
                 $metadata = $params[self::GRPC_CALLABLE_METADATA_INDEX];
                 $headers = $headerDescriptor->getHeader();
-                if (array_key_exists('headers', $metadata)) {
-                    $headers = array_merge($headers, $metadata['headers']);
-                }
-                $params[self::GRPC_CALLABLE_METADATA_INDEX]['headers'] = $headers;
+                $params[self::GRPC_CALLABLE_METADATA_INDEX] = array_merge($headers, $metadata);
                 return call_user_func_array($callable, $params);
             }
         };
@@ -155,6 +152,7 @@ class ApiCallable
     public static function createApiCall($stub, $methodName, CallSettings $settings, $options = [])
     {
         $apiCall = function () use ($stub, $methodName) {
+
             list($response, $status) =
                 call_user_func_array(array($stub, $methodName), func_get_args())->wait();
             if ($status->code == Grpc\STATUS_OK) {

--- a/tests/ApiCallableTest.php
+++ b/tests/ApiCallableTest.php
@@ -426,8 +426,7 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $actualCalls = $stub->actualCalls;
         $this->assertEquals(1, count($actualCalls));
         $expectedMetadata = [
-            'headers' =>
-                ['x-google-apis-agent' => 'testClient/0.0.0;testCodeGen/0.9.0;gax/1.0.0;php/5.5.0']
+            'x-goog-api-client' => ['testClient/0.0.0;testCodeGen/0.9.0;gax/1.0.0;php/5.5.0']
         ];
         $this->assertEquals($expectedMetadata, $actualCalls[0]['metadata']);
     }


### PR DESCRIPTION
Update the agent header to x-goog-api-client

Update the metadata processing so that x-goog-api-client is used (previously, "headers" was appearing in the metadata)