### PR TITLE
Fix auth version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.5",
-        "google/auth": "v0.11",
+        "google/auth": "^0.11",
         "grpc/grpc": "v1.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
@michaelbausor, we goofed on the auth fix earlier. The version should be `^0.11` to match [`google/apiclient`](https://github.com/google/google-api-php-client/blob/master/composer.json#L10), not `0.11`.

Can you merge and tag this as v0.4.1?

Thanks