### PR TITLE
Apply PSR2 formatting to all handwritten code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ install:
   - composer install
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml
-  - vendor/bin/phpcs -l --standard=PSR2 src/
+  - vendor/bin/phpcs --standard=./ruleset.xml
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "autoload": {
         "psr-4": {
-          "Google\\GAX\\":"src/"
+          "Google\\GAX\\":"src/",
+          "Google\\GAX\\UnitTests\\":"tests/"
         },
         "classmap": ["src/generated", "src/generated/well-known-types"]
     }

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="Google-Cloud-PHP-PSR2">
+  <rule ref="PSR2" />
+  <exclude-pattern>src/generated</exclude-pattern>
+  <exclude-pattern>src/Jison</exclude-pattern>
+  <exclude-pattern>src/LongRunning</exclude-pattern>
+  <file>src</file>
+  <file>tests</file>
+</ruleset>

--- a/src/Testing/MockStubTrait.php
+++ b/src/Testing/MockStubTrait.php
@@ -53,12 +53,13 @@ trait MockStubTrait
      * @param array $options
      * @return MockUnaryCall
      */
-    public function _simpleRequest($method,
-                                   $argument,
-                                   $deserialize,
-                                   $metadata = [],
-                                   $options = [])
-    {
+    public function _simpleRequest(
+        $method,
+        $argument,
+        $deserialize,
+        $metadata = [],
+        $options = []
+    ) {
         $this->receivedFuncCalls[] = [$method, $argument::deserialize($argument->serialize())];
         list($response, $status) = array_shift($this->responses);
         return new MockUnaryCall($response, $deserialize, $status);

--- a/src/Testing/MockUnaryCall.php
+++ b/src/Testing/MockUnaryCall.php
@@ -59,7 +59,7 @@ class MockUnaryCall
     {
         $this->response = $response;
         if (is_null($deserialize)) {
-            $deserialize = function($resp) {
+            $deserialize = function ($resp) {
                 return $resp;
             };
         }

--- a/tests/ApiCallableTest.php
+++ b/tests/ApiCallableTest.php
@@ -29,20 +29,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\ApiCallable;
+use Google\GAX\ApiException;
 use Google\GAX\AgentHeaderDescriptor;
 use Google\GAX\BackoffSettings;
 use Google\GAX\CallSettings;
 use Google\GAX\PageStreamingDescriptor;
 use Google\GAX\RetrySettings;
-use Google\GAX\Testing\MockStub;
-use Google\GAX\Testing\MockStatus;
-use Google\GAX\Testing\MockRequest;
-use Google\GAX\Testing\MockResponse;
+use Google\GAX\UnitTests\Mocks\MockStub;
+use Google\GAX\UnitTests\Mocks\MockStatus;
+use Google\GAX\UnitTests\Mocks\MockRequest;
+use Google\GAX\UnitTests\Mocks\MockResponse;
 use google\longrunning\Operation;
 use google\protobuf\EmptyC;
 use google\rpc\Code;
+use PHPUnit_Framework_TestCase;
+use Grpc;
 
 class ApiCallableTest extends PHPUnit_Framework_TestCase
 {
@@ -139,7 +143,8 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
             'totalTimeoutMillis' => 2000]);
         $retrySettings = new RetrySettings(
             [Grpc\STATUS_DEADLINE_EXCEEDED],
-            $backoffSettings);
+            $backoffSettings
+        );
         $callSettings = new CallSettings(['retrySettings' => $retrySettings]);
         $apiCall = ApiCallable::createApiCall($stub, 'takeAction', $callSettings);
         $actualResponse = $apiCall($request, [], []);
@@ -179,12 +184,13 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
             'totalTimeoutMillis' => 3000]);
         $retrySettings = new RetrySettings(
             [Grpc\STATUS_DEADLINE_EXCEEDED],
-            $backoffSettings);
+            $backoffSettings
+        );
         $callSettings = new CallSettings(['retrySettings' => $retrySettings]);
 
         // Use time function that simulates 1100ms elapsing with each call to the stub
         $incrementMillis = 1100;
-        $timeFuncMillis = function() use ($stub, $incrementMillis) {
+        $timeFuncMillis = function () use ($stub, $incrementMillis) {
             $actualCalls = count($stub->actualCalls);
             return $actualCalls * $incrementMillis;
         };
@@ -192,9 +198,13 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $raisedException = null;
         try {
             $apiCall = ApiCallable::createApiCall(
-                $stub, 'takeAction', $callSettings, ['timeFuncMillis' => $timeFuncMillis]);
+                $stub,
+                'takeAction',
+                $callSettings,
+                ['timeFuncMillis' => $timeFuncMillis]
+            );
             $response = $apiCall($request, [], []);
-        } catch (Google\GAX\ApiException $e) {
+        } catch (ApiException $e) {
             $raisedException = $e;
         }
 
@@ -225,7 +235,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ]);
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $this->assertEquals(1, count($stub->actualCalls));
         $actualResources = [];
@@ -255,7 +269,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ]);
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $this->assertEquals(1, count($stub->actualCalls));
         $actualResources = [];
@@ -268,8 +286,10 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         }
         $this->assertEquals(3, count($stub->actualCalls));
         $this->assertEquals(['resource1', 'resource2', 'resource3', 'resource4'], $actualResources);
-        $this->assertEquals(['token', 'nextPageToken1', 'nextPageToken2'],
-            $actualTokens);
+        $this->assertEquals(
+            ['token', 'nextPageToken1', 'nextPageToken2'],
+            $actualTokens
+        );
     }
 
     public function testPageStreamingFixedSizeIterationNoTimeout()
@@ -293,7 +313,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $collectionSize = 2;
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $this->assertEquals(1, count($stub->actualCalls));
         $actualResources = [];
@@ -310,7 +334,7 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      * @expectedExceptionMessage FixedSizeCollection is not supported
      */
     public function testPageStreamingFixedSizeFailPageSizeNotSupported()
@@ -329,13 +353,17 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $collectionSize = 2;
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $response->expandToFixedSizeCollection($collectionSize);
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      * @expectedExceptionMessage No page size parameter found
      */
     public function testPageStreamingFixedSizeFailPageSizeNotSet()
@@ -355,13 +383,17 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $collectionSize = 2;
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $response->expandToFixedSizeCollection($collectionSize);
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      * @expectedExceptionMessage collectionSize parameter is less than the page size
      */
     public function testPageStreamingFixedSizeFailPageSizeTooLarge()
@@ -381,7 +413,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ]);
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $response->expandToFixedSizeCollection($collectionSize);
     }
@@ -405,7 +441,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ]);
         $callSettings = new CallSettings(['timeout' => 1000]);
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', $callSettings, ['pageStreamingDescriptor' => $descriptor]);
+            $stub,
+            'takeAction',
+            $callSettings,
+            ['pageStreamingDescriptor' => $descriptor]
+        );
         $response = $apiCall($request, [], []);
         $this->assertEquals(1, count($stub->actualCalls));
         $actualResources = [];
@@ -428,7 +468,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
             'phpVersion' => '5.5.0',
         ]);
         $apiCall = ApiCallable::createApiCall(
-            $stub, 'takeAction', new CallSettings(), ['headerDescriptor' => $headerDescriptor]);
+            $stub,
+            'takeAction',
+            new CallSettings(),
+            ['headerDescriptor' => $headerDescriptor]
+        );
         $resources = $apiCall(new MockRequest(), [], []);
         $actualCalls = $stub->actualCalls;
         $this->assertEquals(1, count($actualCalls));
@@ -485,7 +529,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ];
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $callStub, 'takeAction', $callSettings, ['longRunningDescriptor' => $descriptor]);
+            $callStub,
+            'takeAction',
+            $callSettings,
+            ['longRunningDescriptor' => $descriptor]
+        );
 
         /* @var $response \Google\GAX\OperationResponse */
         $response = $apiCall($request, [], []);
@@ -547,7 +595,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ];
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $callStub, 'takeAction', $callSettings, ['longRunningDescriptor' => $descriptor]);
+            $callStub,
+            'takeAction',
+            $callSettings,
+            ['longRunningDescriptor' => $descriptor]
+        );
 
         /* @var $response \Google\GAX\OperationResponse */
         $response = $apiCall($request, [], []);
@@ -595,7 +647,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ];
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $callStub, 'takeAction', $callSettings, ['longRunningDescriptor' => $descriptor]);
+            $callStub,
+            'takeAction',
+            $callSettings,
+            ['longRunningDescriptor' => $descriptor]
+        );
 
         /* @var $response \Google\GAX\OperationResponse */
         $response = $apiCall($request, [], []);
@@ -635,7 +691,8 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
             [$responseB, new MockStatus(Grpc\STATUS_OK, '')],
         ];
         $callStub = MockStub::createWithResponseSequence(
-            [[$initialResponse, new MockStatus(Grpc\STATUS_OK, '')]]);
+            [[$initialResponse, new MockStatus(Grpc\STATUS_OK, '')]]
+        );
         $opStub = MockStub::createWithResponseSequence($responseSequence);
         $opClient = OperationResponseTest::createOperationsClient($opStub);
         $descriptor = [
@@ -645,7 +702,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ];
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $callStub, 'takeAction', $callSettings, ['longRunningDescriptor' => $descriptor]);
+            $callStub,
+            'takeAction',
+            $callSettings,
+            ['longRunningDescriptor' => $descriptor]
+        );
 
         /* @var $response \Google\GAX\OperationResponse */
         $response = $apiCall($request, [], []);
@@ -707,7 +768,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ];
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $callStub, 'takeAction', $callSettings, ['longRunningDescriptor' => $descriptor]);
+            $callStub,
+            'takeAction',
+            $callSettings,
+            ['longRunningDescriptor' => $descriptor]
+        );
 
         /* @var $response \Google\GAX\OperationResponse */
         $response = $apiCall($request, [], []);
@@ -758,7 +823,11 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         ];
         $callSettings = new CallSettings();
         $apiCall = ApiCallable::createApiCall(
-            $callStub, 'takeAction', $callSettings, ['longRunningDescriptor' => $descriptor]);
+            $callStub,
+            'takeAction',
+            $callSettings,
+            ['longRunningDescriptor' => $descriptor]
+        );
 
         /* @var $response \Google\GAX\OperationResponse */
         $response = $apiCall($request, [], []);

--- a/tests/BackoffSettingsTest.php
+++ b/tests/BackoffSettingsTest.php
@@ -29,10 +29,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\ApiCallable;
 use Google\GAX\RetrySettings;
 use Google\GAX\BackoffSettings;
+use PHPUnit_Framework_TestCase;
 
 class BackoffSettingsTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/FixedSizeCollectionTest.php
+++ b/tests/FixedSizeCollectionTest.php
@@ -29,18 +29,22 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\Page;
 use Google\GAX\FixedSizeCollection;
 use Google\GAX\PageStreamingDescriptor;
-use Google\GAX\Testing\MockStub;
-use Google\GAX\Testing\MockStatus;
-use Google\GAX\Testing\MockRequest;
-use Google\GAX\Testing\MockResponse;
+use Google\GAX\UnitTests\Mocks\MockStub;
+use Google\GAX\UnitTests\Mocks\MockStatus;
+use Google\GAX\UnitTests\Mocks\MockRequest;
+use Google\GAX\UnitTests\Mocks\MockResponse;
+use PHPUnit_Framework_TestCase;
+use Grpc;
 
 class FixedSizeCollectionTest extends PHPUnit_Framework_TestCase
 {
-    private static function createPage($responseSequence) {
+    private static function createPage($responseSequence)
+    {
         $mockRequest = MockRequest::createPageStreamingRequest('token', 3);
         $stub = MockStub::createWithResponseSequence($responseSequence);
         $descriptor = new PageStreamingDescriptor([
@@ -49,7 +53,7 @@ class FixedSizeCollectionTest extends PHPUnit_Framework_TestCase
             'responsePageTokenField' => 'nextPageToken',
             'resourceField' => 'resource'
         ]);
-        $mockApiCall = function() use ($stub) {
+        $mockApiCall = function () use ($stub) {
             list($response, $status) =
                 call_user_func_array(array($stub, 'takeAction'), func_get_args())->wait();
             return $response;
@@ -57,15 +61,24 @@ class FixedSizeCollectionTest extends PHPUnit_Framework_TestCase
         return new Page([$mockRequest, [], []], $mockApiCall, $descriptor);
     }
 
-    public function testFixedCollectionMethods() {
-        $responseA = MockResponse::createPageStreamingResponse('nextPageToken1',
-            ['resource1', 'resource2']);
-        $responseB = MockResponse::createPageStreamingResponse('nextPageToken2',
-            ['resource3', 'resource4', 'resource5']);
-        $responseC = MockResponse::createPageStreamingResponse('nextPageToken3',
-            ['resource6', 'resource7']);
-        $responseD = MockResponse::createPageStreamingResponse('',
-            ['resource8', 'resource9']);
+    public function testFixedCollectionMethods()
+    {
+        $responseA = MockResponse::createPageStreamingResponse(
+            'nextPageToken1',
+            ['resource1', 'resource2']
+        );
+        $responseB = MockResponse::createPageStreamingResponse(
+            'nextPageToken2',
+            ['resource3', 'resource4', 'resource5']
+        );
+        $responseC = MockResponse::createPageStreamingResponse(
+            'nextPageToken3',
+            ['resource6', 'resource7']
+        );
+        $responseD = MockResponse::createPageStreamingResponse(
+            '',
+            ['resource8', 'resource9']
+        );
         $page = FixedSizeCollectionTest::createPage([
             [$responseA, new MockStatus(Grpc\STATUS_OK, '')],
             [$responseB, new MockStatus(Grpc\STATUS_OK, '')],
@@ -79,8 +92,10 @@ class FixedSizeCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($fixedSizeCollection->hasNextCollection(), true);
         $this->assertEquals($fixedSizeCollection->getNextPageToken(), 'nextPageToken2');
         $results = iterator_to_array($fixedSizeCollection);
-        $this->assertEquals($results,
-            ['resource1', 'resource2', 'resource3', 'resource4', 'resource5']);
+        $this->assertEquals(
+            $results,
+            ['resource1', 'resource2', 'resource3', 'resource4', 'resource5']
+        );
 
         $nextCollection = $fixedSizeCollection->getNextCollection();
 
@@ -88,7 +103,9 @@ class FixedSizeCollectionTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($nextCollection->hasNextCollection(), false);
         $this->assertEquals($nextCollection->getNextPageToken(), '');
         $results = iterator_to_array($nextCollection);
-        $this->assertEquals($results,
-            ['resource6', 'resource7', 'resource8', 'resource9']);
+        $this->assertEquals(
+            $results,
+            ['resource6', 'resource7', 'resource8', 'resource9']
+        );
     }
 }

--- a/tests/Mocks/MockContent.php
+++ b/tests/Mocks/MockContent.php
@@ -29,37 +29,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-namespace Google\GAX\UnitTests;
 
-use Exception;
-use Google\GAX\GrpcConstants;
-use PHPUnit_Framework_TestCase;
-use ReflectionClass;
+namespace Google\GAX\UnitTests\Mocks;
 
-class GrpcConstantsTest extends PHPUnit_Framework_TestCase
+class MockContext
 {
-    public function testGetStatusCodeNames()
+    public $service_url;
+
+    public function __construct($service_url)
     {
-        $statusCodeNames = GrpcConstants::getStatusCodeNames();
-
-        $this->assertTrue(is_array($statusCodeNames));
-        $this->assertFalse(empty($statusCodeNames));
-
-        // test getting the status code names again does not throw exception
-        GrpcConstants::getStatusCodeNames();
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage GrpcConstants::initStatusCodeNames called more than once
-     */
-    public function testInitStatusCodeNamesThrowsException()
-    {
-        $statusCodeNames = GrpcConstants::getStatusCodeNames();
-
-        $reflection = new ReflectionClass('Google\GAX\GrpcConstants');
-        $method = $reflection->getMethod('initStatusCodeNames');
-        $method->setAccessible(true);
-        $method->invoke(new GrpcConstants);
+        $this->service_url = $service_url;
     }
 }

--- a/tests/Mocks/MockGrpcCredentialsHelper.php
+++ b/tests/Mocks/MockGrpcCredentialsHelper.php
@@ -30,18 +30,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Google\GAX\Testing;
+namespace Google\GAX\UnitTests\Mocks;
 
-class MockResponse
+use Google\GAX\GrpcCredentialsHelper;
+
+class MockGrpcCredentialsHelper extends GrpcCredentialsHelper
 {
-    public $nextPageToken;
-    public $resource;
-
-    public static function createPageStreamingResponse($nextPageToken, $resource)
+    protected function getADCCredentials($scopes)
     {
-        $response = new MockResponse();
-        $response->nextPageToken = $nextPageToken;
-        $response->resource = $resource;
-        return $response;
+        return new MockCredentialsLoader($scopes, [
+            [
+                'access_token' => 'adcAccessToken',
+                'expires_in' => '100',
+            ],
+        ]);
+    }
+
+    protected function createSslChannelCredentials()
+    {
+        return "DummySslCreds";
     }
 }

--- a/tests/Mocks/MockRequest.php
+++ b/tests/Mocks/MockRequest.php
@@ -30,15 +30,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Google\GAX\Testing;
+namespace Google\GAX\UnitTests\Mocks;
 
-class MockStatus
+class MockRequest
 {
-    public $code;
-    public $details;
-    public function __construct($code, $details)
+    public $pageToken;
+    public $pageSize;
+
+    public static function createPageStreamingRequest($pageToken, $pageSize = null)
     {
-        $this->code = $code;
-        $this->details = $details;
+        $request = new MockRequest();
+        $request->pageToken = $pageToken;
+        $request->pageSize = $pageSize;
+        return $request;
     }
 }

--- a/tests/Mocks/MockResponse.php
+++ b/tests/Mocks/MockResponse.php
@@ -29,37 +29,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-namespace Google\GAX\UnitTests;
 
-use Exception;
-use Google\GAX\GrpcConstants;
-use PHPUnit_Framework_TestCase;
-use ReflectionClass;
+namespace Google\GAX\UnitTests\Mocks;
 
-class GrpcConstantsTest extends PHPUnit_Framework_TestCase
+class MockResponse
 {
-    public function testGetStatusCodeNames()
+    public $nextPageToken;
+    public $resource;
+
+    public static function createPageStreamingResponse($nextPageToken, $resource)
     {
-        $statusCodeNames = GrpcConstants::getStatusCodeNames();
-
-        $this->assertTrue(is_array($statusCodeNames));
-        $this->assertFalse(empty($statusCodeNames));
-
-        // test getting the status code names again does not throw exception
-        GrpcConstants::getStatusCodeNames();
-    }
-
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage GrpcConstants::initStatusCodeNames called more than once
-     */
-    public function testInitStatusCodeNamesThrowsException()
-    {
-        $statusCodeNames = GrpcConstants::getStatusCodeNames();
-
-        $reflection = new ReflectionClass('Google\GAX\GrpcConstants');
-        $method = $reflection->getMethod('initStatusCodeNames');
-        $method->setAccessible(true);
-        $method->invoke(new GrpcConstants);
+        $response = new MockResponse();
+        $response->nextPageToken = $nextPageToken;
+        $response->resource = $resource;
+        return $response;
     }
 }

--- a/tests/Mocks/MockStatus.php
+++ b/tests/Mocks/MockStatus.php
@@ -30,18 +30,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Google\GAX\Testing;
+namespace Google\GAX\UnitTests\Mocks;
 
-class MockRequest
+class MockStatus
 {
-    public $pageToken;
-    public $pageSize;
-
-    public static function createPageStreamingRequest($pageToken, $pageSize = null)
+    public $code;
+    public $details;
+    public function __construct($code, $details)
     {
-        $request = new MockRequest();
-        $request->pageToken = $pageToken;
-        $request->pageSize = $pageSize;
-        return $request;
+        $this->code = $code;
+        $this->details = $details;
     }
 }

--- a/tests/Mocks/MockStub.php
+++ b/tests/Mocks/MockStub.php
@@ -30,10 +30,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace Google\GAX\Testing;
+namespace Google\GAX\UnitTests\Mocks;
 
 use InvalidArgumentException;
 use UnderflowException;
+use Google\GAX\Testing\MockUnaryCall;
 
 class MockStub
 {

--- a/tests/OperationResponseTest.php
+++ b/tests/OperationResponseTest.php
@@ -29,12 +29,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\OperationResponse;
 use google\longrunning\Operation;
 use Google\GAX\LongRunning\OperationsClient;
 use google\protobuf\Any;
 use google\rpc\Status;
+use PHPUnit_Framework_TestCase;
 
 class OperationResponseTest extends PHPUnit_Framework_TestCase
 {
@@ -124,12 +126,14 @@ class OperationResponseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(self::createStatus(0, "metadata"), $op->getMetadata());
     }
 
-    public static function createAny($value) {
+    public static function createAny($value)
+    {
         $any = new Any();
         return $any->setValue($value->serialize());
     }
 
-    public static function createStatus($code, $message) {
+    public static function createStatus($code, $message)
+    {
         $value = new Status();
         return $value->setCode($code)->setMessage($message);
     }

--- a/tests/PageStreamingDescriptorTest.php
+++ b/tests/PageStreamingDescriptorTest.php
@@ -29,8 +29,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\PageStreamingDescriptor;
+use PHPUnit_Framework_TestCase;
 
 class PageStreamingDescriptorTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -29,13 +29,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\Page;
 use Google\GAX\PageStreamingDescriptor;
-use Google\GAX\Testing\MockStub;
-use Google\GAX\Testing\MockStatus;
-use Google\GAX\Testing\MockRequest;
-use Google\GAX\Testing\MockResponse;
+use Google\GAX\UnitTests\Mocks\MockStub;
+use Google\GAX\UnitTests\Mocks\MockStatus;
+use Google\GAX\UnitTests\Mocks\MockRequest;
+use Google\GAX\UnitTests\Mocks\MockResponse;
+use PHPUnit_Framework_TestCase;
+use Grpc;
 
 class PageTest extends PHPUnit_Framework_TestCase
 {
@@ -48,7 +51,7 @@ class PageTest extends PHPUnit_Framework_TestCase
             'responsePageTokenField' => 'nextPageToken',
             'resourceField' => 'resource'
         ]);
-        $mockApiCall = function() use ($stub) {
+        $mockApiCall = function () use ($stub) {
             list($response, $status) =
                 call_user_func_array(array($stub, 'takeAction'), func_get_args())->wait();
             return $response;
@@ -75,7 +78,7 @@ class PageTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      * @expectedExceptionMessage Could not complete getNextPage operation
      */
     public function testNextPageMethodsFailWithNoNextPage()
@@ -90,7 +93,7 @@ class PageTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      * @expectedExceptionMessage pageSize argument was defined, but the method does not
      */
     public function testNextPageMethodsFailWithPageSizeUnsupported()
@@ -107,8 +110,10 @@ class PageTest extends PHPUnit_Framework_TestCase
 
     public function testPageElementMethods()
     {
-        $response = MockResponse::createPageStreamingResponse('nextPageToken1',
-            ['resource1', 'resource2', 'resource3']);
+        $response = MockResponse::createPageStreamingResponse(
+            'nextPageToken1',
+            ['resource1', 'resource2', 'resource3']
+        );
         $page = PageTest::createPage([
             [$response, new MockStatus(Grpc\STATUS_OK, '')],
         ]);

--- a/tests/PagedListResponseTest.php
+++ b/tests/PagedListResponseTest.php
@@ -29,13 +29,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\PagedListResponse;
 use Google\GAX\PageStreamingDescriptor;
-use Google\GAX\Testing\MockStub;
-use Google\GAX\Testing\MockStatus;
-use Google\GAX\Testing\MockRequest;
-use Google\GAX\Testing\MockResponse;
+use Google\GAX\UnitTests\Mocks\MockStub;
+use Google\GAX\UnitTests\Mocks\MockRequest;
+use Google\GAX\UnitTests\Mocks\MockResponse;
+use PHPUnit_Framework_TestCase;
 
 class PagedListResponseTest extends PHPUnit_Framework_TestCase
 {
@@ -49,7 +50,7 @@ class PagedListResponseTest extends PHPUnit_Framework_TestCase
         ]);
         $response = MockResponse::createPageStreamingResponse('nextPageToken1', ['resource1']);
         $stub = MockStub::create($response);
-        $mockApiCall = function() use ($stub) {
+        $mockApiCall = function () use ($stub) {
             list($response, $status) =
                 call_user_func_array(array($stub, 'takeAction'), func_get_args())->wait();
             return $response;

--- a/tests/PathTemplateTest.php
+++ b/tests/PathTemplateTest.php
@@ -29,19 +29,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+namespace Google\GAX\UnitTests;
 
 use Google\GAX\PathTemplate;
+use PHPUnit_Framework_TestCase;
 
 class PathTemplateTest extends PHPUnit_Framework_TestCase
 {
     public function testCount()
     {
         $this->assertEquals(
-            count(new PathTemplate('a/b/**/*/{a=hello/world}')), 6);
+            count(new PathTemplate('a/b/**/*/{a=hello/world}')),
+            6
+        );
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailInvalidToken()
     {
@@ -49,7 +53,7 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailWhenImpossibleMatch01()
     {
@@ -58,7 +62,7 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailWhenImpossibleMatch02()
     {
@@ -67,7 +71,7 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailMismatchedLiteral()
     {
@@ -76,7 +80,7 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailWhenMultiplePathWildcards()
     {
@@ -84,7 +88,7 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailIfInnerBinding()
     {
@@ -92,7 +96,7 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testFailUnexpectedEof()
     {
@@ -104,13 +108,18 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
         $template = new PathTemplate('buckets/*/*/objects/*');
         $this->assertEquals(
             ['$0' => 'f', '$1' => 'o', '$2' => 'bar'],
-            $template->match('buckets/f/o/objects/bar'));
+            $template->match('buckets/f/o/objects/bar')
+        );
         $template = new PathTemplate('/buckets/{hello}');
-        $this->assertEquals(['hello' => 'world'],
-            $template->match('buckets/world'));
+        $this->assertEquals(
+            ['hello' => 'world'],
+            $template->match('buckets/world')
+        );
         $template = new PathTemplate('/buckets/{hello=*}');
-        $this->assertEquals(['hello' => 'world'],
-            $template->match('buckets/world'));
+        $this->assertEquals(
+            ['hello' => 'world'],
+            $template->match('buckets/world')
+        );
     }
 
     public function testMatchEscapedChars()
@@ -118,7 +127,8 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
         $template = new PathTemplate('buckets/*/objects');
         $this->assertEquals(
             ['$0' => 'hello%2F%2Bworld'],
-            $template->match('buckets/hello%2F%2Bworld/objects'));
+            $template->match('buckets/hello%2F%2Bworld/objects')
+        );
     }
 
     public function testMatchTemplateWithUnboundedWildcard()
@@ -126,7 +136,8 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
         $template = new PathTemplate('buckets/*/objects/**');
         $this->assertEquals(
             ['$0' => 'foo', '$1' => 'bar/baz'],
-            $template->match('buckets/foo/objects/bar/baz'));
+            $template->match('buckets/foo/objects/bar/baz')
+        );
     }
 
     public function testMatchWithUnboundInMiddle()
@@ -134,19 +145,21 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
         $template = new PathTemplate('bar/**/foo/*');
         $this->assertEquals(
             ['$0' => 'foo/foo', '$1' => 'bar'],
-            $template->match('bar/foo/foo/foo/bar'));
+            $template->match('bar/foo/foo/foo/bar')
+        );
     }
 
     public function testRenderAtomicResource()
     {
         $template = new PathTemplate('buckets/*/*/*/objects/*');
         $url = $template->render(
-            ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b']);
+            ['$0' => 'f', '$1' => 'o', '$2' => 'o', '$3' => 'google.com:a-b']
+        );
         $this->assertEquals($url, 'buckets/f/o/o/objects/google.com:a-b');
     }
 
     /**
-     * @expectedException Google\GAX\ValidationException
+     * @expectedException \Google\GAX\ValidationException
      */
     public function testRenderFailWhenTooFewVariables()
     {
@@ -167,34 +180,48 @@ class PathTemplateTest extends PHPUnit_Framework_TestCase
         $this->assertEquals((string) $template, 'bar/{$0=**}/foo/{$1=*}');
         $template = new PathTemplate('buckets/*/objects/*');
         $this->assertEquals(
-            (string) ($template), 'buckets/{$0=*}/objects/{$1=*}');
+            (string) ($template),
+            'buckets/{$0=*}/objects/{$1=*}'
+        );
         $template = new PathTemplate('/buckets/{hello}');
         $this->assertEquals((string) ($template), 'buckets/{hello=*}');
         $template = new PathTemplate('/buckets/{hello=what}/{world}');
         $this->assertEquals(
-            (string) ($template), 'buckets/{hello=what}/{world=*}');
+            (string) ($template),
+            'buckets/{hello=what}/{world=*}'
+        );
         $template = new PathTemplate('/buckets/helloazAZ09-.~_what');
         $this->assertEquals(
-            (string) ($template), 'buckets/helloazAZ09-.~_what');
+            (string) ($template),
+            'buckets/helloazAZ09-.~_what'
+        );
     }
 
     public function testSubstitutionOddChars()
     {
         $template = new PathTemplate('projects/{project}/topics/{topic}');
         $url = $template->render(
-            ['project' => 'google.com:proj-test', 'topic' => 'some-topic']);
-        $this->assertEquals($url,
-            'projects/google.com:proj-test/topics/some-topic');
+            ['project' => 'google.com:proj-test', 'topic' => 'some-topic']
+        );
+        $this->assertEquals(
+            $url,
+            'projects/google.com:proj-test/topics/some-topic'
+        );
         $template = new PathTemplate('projects/{project}/topics/{topic}');
         $url = $template->render(
-            ['project' => 'g.,;:~`!@#$%^&()+-', 'topic' => 'sdf<>,.?[]']);
-        $this->assertEquals($url,
-            'projects/g.,;:~`!@#$%^&()+-/topics/sdf<>,.?[]');
+            ['project' => 'g.,;:~`!@#$%^&()+-', 'topic' => 'sdf<>,.?[]']
+        );
+        $this->assertEquals(
+            $url,
+            'projects/g.,;:~`!@#$%^&()+-/topics/sdf<>,.?[]'
+        );
     }
 
     public function testLeadingSlash()
     {
         $this->assertEquals(
-            count(new PathTemplate('/a/b/**/*/{a=hello/world}')), 6);
+            count(new PathTemplate('/a/b/**/*/{a=hello/world}')),
+            6
+        );
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,10 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 require_once __DIR__ . '/../vendor/autoload.php';
-require_once __DIR__ . '/mocks/MockRequest.php';
-require_once __DIR__ . '/mocks/MockResponse.php';
-require_once __DIR__ . '/mocks/MockStatus.php';
-require_once __DIR__ . '/mocks/MockStub.php';
 
 date_default_timezone_set('UTC');
 ini_set('error_reporting', E_ALL);


### PR DESCRIPTION
Added namespaces to unit tests, which prompted much of the other changes.