### PR TITLE
Handle insecure credentials

### DIFF
--- a/src/GrpcCredentialsHelper.php
+++ b/src/GrpcCredentialsHelper.php
@@ -130,7 +130,8 @@ class GrpcCredentialsHelper
     public function createStub($generatedCreateStub, $serviceAddress, $port, $options = [])
     {
         $stubOpts = [];
-        if (empty($options['sslCreds'])) {
+        // We need to use array_key_exists here because null is a valid value
+        if (!array_key_exists('sslCreds', $options)) {
             $stubOpts['credentials'] = $this->createSslChannelCredentials();
         } else {
             $stubOpts['credentials'] = $options['sslCreds'];

--- a/tests/GrpcCredentialsHelperTest.php
+++ b/tests/GrpcCredentialsHelperTest.php
@@ -144,4 +144,25 @@ class GrpcCredentialsHelperTest extends PHPUnit_Framework_TestCase
             $createStubResult['stubOpts']['grpc.ssl_target_name_override']
         );
     }
+
+    public function testCreateStubWithInsecureSslCreds()
+    {
+        $grpcCredentialsHelper = new MockGrpcCredentialsHelper($this->defaultScope);
+        $createStubCallback = function ($hostname, $stubOpts) {
+            return ['hostname' => $hostname, 'stubOpts' => $stubOpts];
+        };
+        $insecureCreds = \Grpc\ChannelCredentials::createInsecure();
+        $createStubResult = $grpcCredentialsHelper->createStub(
+            $createStubCallback,
+            'my-service-address',
+            8443,
+            ['sslCreds' => $insecureCreds]
+        );
+        $this->assertEquals('my-service-address:8443', $createStubResult['hostname']);
+        $this->assertEquals($insecureCreds, $createStubResult['stubOpts']['credentials']);
+        $this->assertEquals(
+            'my-service-address:8443',
+            $createStubResult['stubOpts']['grpc.ssl_target_name_override']
+        );
+    }
 }


### PR DESCRIPTION
Insecure credentials are represented as null, so we need to accept a null value. See https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/channel_credentials.c#L198