### PR TITLE
Include metadata in ApiException toString method

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -63,18 +63,27 @@ class ApiException extends Exception
         return $this->metadata;
     }
 
-    // custom string representation of object
+    /**
+     * @return string
+     */
+    public function getMetadataAsString()
+    {
+        $decodedMetadata = Serializer::decodeMetadata($this->metadata);
+        return json_encode($decodedMetadata);
+    }
+
+    /**
+     * String representation of ApiException
+     * @return string
+     */
     public function __toString()
     {
         $str = __CLASS__ . ": [{$this->code}]: {$this->message}\n";
         if (isset($this->metadata) && count($this->metadata) > 0) {
-            $str .= "Metadata:\n" . json_encode($this->metadata);
-            /*
-            foreach ($this->metadata as $key => $value) {
-                $str .= "\t$key: $value\n";
-            }
-            */
+            $str .= "Metadata: " . $this->getMetadataAsString();
         }
         return $str;
     }
+
+
 }

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -38,9 +38,11 @@ class ApiException extends Exception
     private $metadata;
     private $basicMessage;
 
-    public function __construct($message, $code, \Exception $previous = null)
+    public function __construct($message, $code, \Exception $previous = null, $metadata = null, $basicMessage = null)
     {
         parent::__construct($message, $code, $previous);
+        $this->metadata = $metadata;
+        $this->basicMessage = isset($basicMessage) ? $basicMessage : $message;
     }
 
     /**
@@ -62,11 +64,7 @@ class ApiException extends Exception
 
         $message = json_encode($messageData, JSON_PRETTY_PRINT);
 
-        $ex = new ApiException($message, $code);
-        $ex->basicMessage = $basicMessage;
-        $ex->metadata = $metadata;
-
-        return $ex;
+        return new ApiException($message, $code, null, $metadata, $basicMessage);
     }
 
     public function getBasicMessage()

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -84,6 +84,4 @@ class ApiException extends Exception
         }
         return $str;
     }
-
-
 }

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -88,10 +88,6 @@ class ApiException extends Exception
      */
     public function __toString()
     {
-        $str = __CLASS__ . ": [{$this->code}]: {$this->message}\n";
-        if (isset($this->metadata) && count($this->metadata) > 0) {
-            $str .= "Metadata: " . $this->getMetadataAsString();
-        }
-        return $str;
+        return __CLASS__ . ": $this->message\n";
     }
 }

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -66,6 +66,15 @@ class ApiException extends Exception
     // custom string representation of object
     public function __toString()
     {
-        return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+        $str = __CLASS__ . ": [{$this->code}]: {$this->message}\n";
+        if (isset($this->metadata) && count($this->metadata) > 0) {
+            $str .= "Metadata:\n" . json_encode($this->metadata);
+            /*
+            foreach ($this->metadata as $key => $value) {
+                $str .= "\t$key: $value\n";
+            }
+            */
+        }
+        return $str;
     }
 }

--- a/src/GrpcConstants.php
+++ b/src/GrpcConstants.php
@@ -42,7 +42,7 @@ use InvalidArgumentException;
 class GrpcConstants
 {
     private static $statusCodeNames;
-    private static $statusCodeNamesInverted;
+    private static $statusCodesToNames;
 
     /**
      * This should not be called outside of the implementation file.
@@ -71,7 +71,7 @@ class GrpcConstants
             'UNIMPLEMENTED' => Grpc\STATUS_UNIMPLEMENTED,
             'UNKNOWN' => Grpc\STATUS_UNKNOWN
         ];
-        self::$statusCodeNamesInverted = array_flip(self::$statusCodeNames);
+        self::$statusCodesToNames = array_flip(self::$statusCodeNames);
     }
 
     /**
@@ -92,10 +92,10 @@ class GrpcConstants
      */
     public static function getStatusCodesToNamesMap()
     {
-        if (!self::$statusCodeNamesInverted) {
+        if (!self::$statusCodesToNames) {
             self::initStatusCodeNames();
         }
-        return self::$statusCodeNamesInverted;
+        return self::$statusCodesToNames;
     }
 
     /**
@@ -104,7 +104,7 @@ class GrpcConstants
      */
     public static function getCodeFromStatusName($name)
     {
-        $codeNames = self::getStatusNamesToCodesMap();
+        $codeNames = self::getStatusCodeNames();
         if (!isset($codeNames[$name])) {
             return -1;
         }

--- a/src/GrpcConstants.php
+++ b/src/GrpcConstants.php
@@ -102,7 +102,8 @@ class GrpcConstants
      * @param string $name
      * @return int
      */
-    public static function getCodeFromStatusName($name) {
+    public static function getCodeFromStatusName($name)
+    {
         $codeNames = self::getStatusNamesToCodesMap();
         if (!isset($codeNames[$name])) {
             return -1;
@@ -114,7 +115,8 @@ class GrpcConstants
      * @param int $code
      * @return string
      */
-    public static function getStatusNameFromCode($code) {
+    public static function getStatusNameFromCode($code)
+    {
         $codeNames = self::getStatusCodesToNamesMap();
         if (!isset($codeNames[$code])) {
             return "UNEXPECTED_CODE";

--- a/src/GrpcConstants.php
+++ b/src/GrpcConstants.php
@@ -32,7 +32,9 @@
 
 namespace Google\GAX;
 
+use Exception;
 use Grpc;
+use InvalidArgumentException;
 
 /**
  * Holds constants necessary for interacting with gRPC.
@@ -40,6 +42,7 @@ use Grpc;
 class GrpcConstants
 {
     private static $statusCodeNames;
+    private static $statusCodeNamesInverted;
 
     /**
      * This should not be called outside of the implementation file.
@@ -47,7 +50,7 @@ class GrpcConstants
     private static function initStatusCodeNames()
     {
         if (!empty(self::$statusCodeNames)) {
-            throw new \Exception("GrpcConstants::initStatusCodeNames called more than once");
+            throw new Exception("GrpcConstants::initStatusCodeNames called more than once");
         }
         self::$statusCodeNames = [
             'ABORTED' => Grpc\STATUS_ABORTED,
@@ -68,6 +71,7 @@ class GrpcConstants
             'UNIMPLEMENTED' => Grpc\STATUS_UNIMPLEMENTED,
             'UNKNOWN' => Grpc\STATUS_UNKNOWN
         ];
+        self::$statusCodeNamesInverted = array_flip(self::$statusCodeNames);
     }
 
     /**
@@ -80,5 +84,41 @@ class GrpcConstants
             self::initStatusCodeNames();
         }
         return self::$statusCodeNames;
+    }
+
+    /**
+     * Provides an array that maps from status codes to status names.
+     * @return array
+     */
+    public static function getStatusCodesToNamesMap()
+    {
+        if (!self::$statusCodeNamesInverted) {
+            self::initStatusCodeNames();
+        }
+        return self::$statusCodeNamesInverted;
+    }
+
+    /**
+     * @param string $name
+     * @return int
+     */
+    public static function getCodeFromStatusName($name) {
+        $codeNames = self::getStatusNamesToCodesMap();
+        if (!isset($codeNames[$name])) {
+            return -1;
+        }
+        return $codeNames[$name];
+    }
+
+    /**
+     * @param int $code
+     * @return string
+     */
+    public static function getStatusNameFromCode($code) {
+        $codeNames = self::getStatusCodesToNamesMap();
+        if (!isset($codeNames[$code])) {
+            return "UNEXPECTED_CODE";
+        }
+        return $codeNames[$code];
     }
 }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -1,0 +1,125 @@
+<?php
+/*
+ * Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace Google\GAX;
+
+/**
+ * Collection of methods to help with serialization of protobuf objects
+ */
+class Serializer
+{
+    private static $jsonCodec;
+    private static $phpArrayCodec;
+
+    private static $metadataKnownTypes = [
+        'google.rpc.retryinfo-bin' => '\google\rpc\RetryInfo',
+        'google.rpc.debuginfo-bin' => '\google\rpc\DebugInfo',
+        'google.rpc.quotafailure-bin' => '\google\rpc\QuotaFailure',
+        'google.rpc.badrequest-bin' => '\google\rpc\BadRequest',
+        'google.rpc.requestinfo-bin' => '\google\rpc\RequestInfo',
+        'google.rpc.resourceinfo-bin' => '\google\rpc\ResourceInfo',
+        'google.rpc.help-bin' => '\google\rpc\Help',
+        'google.rpc.localizedmessage-bin' => '\google\rpc\LocalizedMessage',
+    ];
+
+    private static function getJsonCodec()
+    {
+        if (is_null(self::$jsonCodec)) {
+            self::$jsonCodec = new \DrSlump\Protobuf\Codec\Json();
+        }
+        return self::$jsonCodec;
+    }
+
+    private static function getPhpArrayCodec()
+    {
+        if (is_null(self::$phpArrayCodec)) {
+            self::$phpArrayCodec = new \DrSlump\Protobuf\Codec\PhpArray();
+        }
+        return self::$phpArrayCodec;
+    }
+
+    /**
+     * @param \DrSlump\Protobuf\Message $message
+     * @return string
+     */
+    public static function serializeToJson($message)
+    {
+        return $message->serialize(self::getJsonCodec());
+    }
+
+    /**
+     * @param \DrSlump\Protobuf\Message $message
+     * @return string
+     */
+    public static function serializeToPhpArray($message)
+    {
+        return $message->serialize(self::getPhpArrayCodec());
+    }
+
+    /**
+     * Decode metadata received from gRPC status object
+     * @param $metadata
+     * @return array
+     */
+    public static function decodeMetadata($metadata)
+    {
+        if (is_null($metadata) || count($metadata) == 0) {
+            return [];
+        }
+        $result = [];
+        foreach ($metadata as $key => $values) {
+            $decodedValues = [];
+            foreach ($values as $value) {
+                if (self::hasBinaryHeaderSuffix($key)) {
+                    if (isset(self::$metadataKnownTypes[$key])) {
+                        $class = self::$metadataKnownTypes[$key];
+                        $message = new $class();
+                        $message->parse($value);
+                        $decodedValue = self::serializeToPhpArray($message);
+                    } else {
+                        // The metadata contains an unexpected binary type
+                        $decodedValue = "<Binary Data>";
+                    }
+                } else {
+                    $decodedValue = $value;
+                }
+                $decodedValues[] = $decodedValue;
+            }
+            $result[$key] = $decodedValues;
+        }
+        return $result;
+    }
+
+    private static function hasBinaryHeaderSuffix($key)
+    {
+        return substr_compare($key, "-bin", strlen($key) - 4) === 0;
+    }
+}

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -32,6 +32,7 @@
 namespace Google\GAX\UnitTests;
 
 use Google\GAX\ApiException;
+use Google\GAX\Serializer;
 use google\protobuf\Duration;
 use google\rpc\BadRequest;
 use google\rpc\DebugInfo;
@@ -71,10 +72,16 @@ class ApiExceptionTest extends PHPUnit_Framework_TestCase
 
         $apiException = ApiException::createFromStdClass($status);
 
+        $expectedMessage = json_encode([
+            'message' => 'testWithMetadata',
+            'code' => Grpc\STATUS_OK,
+            'status' => 'OK',
+            'details' => $metadataArray
+        ], JSON_PRETTY_PRINT);
+
         $this->assertSame(Grpc\STATUS_OK, $apiException->getCode());
-        $this->assertSame('testWithMetadata', $apiException->getMessage());
+        $this->assertSame($expectedMessage, $apiException->getMessage());
         $this->assertSame($metadata, $apiException->getMetadata());
-        $this->assertSame(json_encode($metadataArray), $apiException->getMetadataAsString());
     }
 
     public function getMetadata()

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -55,8 +55,15 @@ class ApiExceptionTest extends PHPUnit_Framework_TestCase
 
         $apiException = ApiException::createFromStdClass($status);
 
+        $expectedMessage = json_encode([
+            'message' => 'testWithoutMetadata',
+            'code' => Grpc\STATUS_OK,
+            'status' => 'OK',
+            'details' => []
+        ], JSON_PRETTY_PRINT);
+
         $this->assertSame(Grpc\STATUS_OK, $apiException->getCode());
-        $this->assertSame('testWithoutMetadata', $apiException->getMessage());
+        $this->assertSame($expectedMessage, $apiException->getMessage());
         $this->assertNull($apiException->getMetadata());
     }
 

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -32,6 +32,15 @@
 namespace Google\GAX\UnitTests;
 
 use Google\GAX\ApiException;
+use google\protobuf\Duration;
+use google\rpc\BadRequest;
+use google\rpc\DebugInfo;
+use google\rpc\Help;
+use google\rpc\LocalizedMessage;
+use google\rpc\QuotaFailure;
+use google\rpc\RequestInfo;
+use google\rpc\ResourceInfo;
+use google\rpc\RetryInfo;
 use PHPUnit_Framework_TestCase;
 use Grpc;
 
@@ -50,17 +59,69 @@ class ApiExceptionTest extends PHPUnit_Framework_TestCase
         $this->assertNull($apiException->getMetadata());
     }
 
-    public function testWithMetadata()
+    /**
+     * @dataProvider getMetadata
+     */
+    public function testWithMetadata($metadata, $metadataArray)
     {
         $status = new \stdClass();
         $status->code = Grpc\STATUS_OK;
         $status->details = 'testWithMetadata';
-        $status->metadata = ['metadata'];
+        $status->metadata = $metadata;
 
         $apiException = ApiException::createFromStdClass($status);
 
         $this->assertSame(Grpc\STATUS_OK, $apiException->getCode());
         $this->assertSame('testWithMetadata', $apiException->getMessage());
-        $this->assertSame(['metadata'], $apiException->getMetadata());
+        $this->assertSame($metadata, $apiException->getMetadata());
+        $this->assertSame(json_encode($metadataArray), $apiException->getMetadataAsString());
+    }
+
+    public function getMetadata()
+    {
+        $retryInfo = new RetryInfo();
+        $duration = new Duration();
+        $duration->setSeconds(1);
+        $duration->setNanos(2);
+        $retryInfo->setRetryDelay($duration);
+
+        $unknownBinData = ['unknown-bin' => ['<Binary Data>']];
+        $asciiData = ['ascii' => ['ascii-data']];
+        $retryInfoData = [
+            'google.rpc.retryinfo-bin' => [
+                [
+                    'retry_delay' => [
+                        'seconds' => 1,
+                        'nanos' => 2,
+                    ]
+                ]
+            ]
+        ];
+        $allKnownTypesData = [
+            'google.rpc.retryinfo-bin' => [[]],
+            'google.rpc.debuginfo-bin' => [[]],
+            'google.rpc.quotafailure-bin' => [[]],
+            'google.rpc.badrequest-bin' => [[]],
+            'google.rpc.requestinfo-bin' => [[]],
+            'google.rpc.resourceinfo-bin' => [[]],
+            'google.rpc.help-bin' => [[]],
+            'google.rpc.localizedmessage-bin' => [[]],
+        ];
+
+        return [
+            [['unknown-bin' => ['some-data-that-should-not-appear']], $unknownBinData],
+            [['ascii' => ['ascii-data']], $asciiData],
+            [['google.rpc.retryinfo-bin' => [$retryInfo->serialize()]], $retryInfoData],
+            [[
+                'google.rpc.retryinfo-bin' => [(new RetryInfo())->serialize()],
+                'google.rpc.debuginfo-bin' => [(new DebugInfo())->serialize()],
+                'google.rpc.quotafailure-bin' => [(new QuotaFailure())->serialize()],
+                'google.rpc.badrequest-bin' => [(new BadRequest())->serialize()],
+                'google.rpc.requestinfo-bin' => [(new RequestInfo())->serialize()],
+                'google.rpc.resourceinfo-bin' => [(new ResourceInfo())->serialize()],
+                'google.rpc.help-bin' => [(new Help())->serialize()],
+                'google.rpc.localizedmessage-bin' => [(new LocalizedMessage())->serialize()],
+            ], $allKnownTypesData],
+        ];
     }
 }


### PR DESCRIPTION
An uncaught ApiException will now also display the metadata information, which can be critical to debugging.