### PR TITLE
Check retry_codes_name, bump auth dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.5",
-        "google/auth": "^0.11",
+        "google/auth": "^1.0",
         "grpc/grpc": "v1.0.*"
     },
     "require-dev": {

--- a/src/CallSettings.php
+++ b/src/CallSettings.php
@@ -132,7 +132,8 @@ class CallSettings
         $codes = [];
         if (!empty($retryCodes)) {
             foreach ($retryCodes as $retryCodesName => $retryCodeList) {
-                if ($retryCodesName === $methodConfig['retry_codes_name'] &&
+                if (isset($methodConfig['retry_codes_name']) &&
+                    $retryCodesName === $methodConfig['retry_codes_name'] &&
                     !empty($retryCodeList)) {
                     foreach ($retryCodeList as $retryCodeName) {
                         if (!array_key_exists($retryCodeName, $statusCodes)) {


### PR DESCRIPTION
- Check retry_codes_name is set, otherwise can see undefined index errors when php.ini error reporting is set to strict
- Bump auth dependency to enable https://github.com/GoogleCloudPlatform/google-cloud-php/pull/535 (cc @bshaffer @jdpedrie @dwsupplee)