### PR TITLE
Bump version to 0.20.0 for release

### DIFF
--- a/src/AgentHeaderDescriptor.php
+++ b/src/AgentHeaderDescriptor.php
@@ -40,7 +40,7 @@ class AgentHeaderDescriptor
     const AGENT_HEADER_KEY = 'x-goog-api-client';
     // TODO(michaelbausor): include bumping this version in a streamlined
     // release process. Issue: https://github.com/googleapis/gax-php/issues/48
-    const GAX_VERSION = '0.10.0';
+    const GAX_VERSION = '0.20.0';
     const UNKNOWN_VERSION = '';
 
     private $metricsHeaders;


### PR DESCRIPTION
Bumping from 0.10.0 to 0.20.0 to indicate the major nature of the change of protobuf implementations