### PR TITLE
Bidi streaming resources fix

### DIFF
--- a/src/BidiStream.php
+++ b/src/BidiStream.php
@@ -140,7 +140,11 @@ class BidiStream
             if (count($this->pendingResources) === 0) {
                 $response = $this->call->read();
                 if (!is_null($response)) {
-                    $this->pendingResources = array_reverse($response->$resourcesGetMethod());
+                    $pendingResources = [];
+                    foreach ($response->$resourcesGetMethod() as $resource) {
+                        $pendingResources[] = $resource;
+                    }
+                    $this->pendingResources = array_reverse($pendingResources);
                 }
             }
             $result = array_pop($this->pendingResources);

--- a/tests/ApiCallableTest.php
+++ b/tests/ApiCallableTest.php
@@ -48,6 +48,8 @@ use Google\GAX\UnitTests\Mocks\MockPageStreamingRequest;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
 use Google\Longrunning\Operation;
 use Google\Protobuf\GPBEmpty;
+use Google\Protobuf\Internal\GPBType;
+use Google\Protobuf\Internal\RepeatedField;
 use Google\Rpc\Code;
 use Google\Rpc\Status;
 use PHPUnit_Framework_TestCase;
@@ -1323,9 +1325,13 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $request->setCode(Grpc\STATUS_OK);
         $request->setMessage('request');
         $resources = ['resource1', 'resource2'];
+        $repeatedField = new RepeatedField(GPBType::STRING);
+        foreach ($resources as $resource) {
+            $repeatedField[] = $resource;
+        }
         $response = MockPageStreamingResponse::createPageStreamingResponse(
             'nextPageToken',
-            $resources
+            $repeatedField
         );
         $descriptor = [
             'grpcStreamingType' => 'BidiStreaming',

--- a/tests/ApiCallableTest.php
+++ b/tests/ApiCallableTest.php
@@ -1185,9 +1185,13 @@ class ApiCallableTest extends PHPUnit_Framework_TestCase
         $request->setCode(Grpc\STATUS_OK);
         $request->setMessage('request');
         $resources = ['resource1', 'resource2'];
+        $repeatedField = new RepeatedField(GPBType::STRING);
+        foreach ($resources as $resource) {
+            $repeatedField[] = $resource;
+        }
         $response = MockPageStreamingResponse::createPageStreamingResponse(
             'nextPageToken',
-            $resources
+            $repeatedField
         );
         $responses = [$response];
         $descriptor = [

--- a/tests/BidiStreamTest.php
+++ b/tests/BidiStreamTest.php
@@ -35,6 +35,8 @@ use Google\GAX\BidiStream;
 use Google\GAX\Testing\MockBidiStreamingCall;
 use Google\GAX\Testing\MockStatus;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
+use Google\Protobuf\Internal\GPBType;
+use Google\Protobuf\Internal\RepeatedField;
 use Grpc;
 use PHPUnit_Framework_TestCase;
 
@@ -297,9 +299,14 @@ class BidiStreamTest extends PHPUnit_Framework_TestCase
     public function testResourcesSuccess()
     {
         $resources = ['resource1', 'resource2', 'resource3'];
+        $repeatedField1 = new RepeatedField(GPBType::STRING);
+        $repeatedField1[] = 'resource1';
+        $repeatedField2 = new RepeatedField(GPBType::STRING);
+        $repeatedField2[] = 'resource2';
+        $repeatedField2[] = 'resource3';
         $responses = [
-            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', ['resource1']),
-            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', ['resource2', 'resource3'])
+            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', $repeatedField1),
+            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1',  $repeatedField2)
         ];
         $call = new MockBidiStreamingCall($responses);
         $stream = new BidiStream($call, [

--- a/tests/BidiStreamTest.php
+++ b/tests/BidiStreamTest.php
@@ -306,7 +306,7 @@ class BidiStreamTest extends PHPUnit_Framework_TestCase
         $repeatedField2[] = 'resource3';
         $responses = [
             MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', $repeatedField1),
-            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1',  $repeatedField2)
+            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', $repeatedField2)
         ];
         $call = new MockBidiStreamingCall($responses);
         $stream = new BidiStream($call, [

--- a/tests/ServerStreamTest.php
+++ b/tests/ServerStreamTest.php
@@ -35,6 +35,8 @@ use Google\GAX\ServerStream;
 use Google\GAX\Testing\MockServerStreamingCall;
 use Google\GAX\Testing\MockStatus;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
+use Google\Protobuf\Internal\GPBType;
+use Google\Protobuf\Internal\RepeatedField;
 use Grpc;
 use PHPUnit_Framework_TestCase;
 
@@ -153,9 +155,14 @@ class ServerStreamTest extends PHPUnit_Framework_TestCase
     public function testResourcesSuccess()
     {
         $resources = ['resource1', 'resource2', 'resource3'];
+        $repeatedField1 = new RepeatedField(GPBType::STRING);
+        $repeatedField1[] = 'resource1';
+        $repeatedField2 = new RepeatedField(GPBType::STRING);
+        $repeatedField2[] = 'resource2';
+        $repeatedField2[] = 'resource3';
         $responses = [
-            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', ['resource1']),
-            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', ['resource2', 'resource3'])
+            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', $repeatedField1),
+            MockPageStreamingResponse::createPageStreamingResponse('nextPageToken1', $repeatedField2)
         ];
         $call = new MockServerStreamingCall($responses);
         $stream = new ServerStream($call, [


### PR DESCRIPTION
- Fix bidi resources streaming when repeated field methods return a RepeatedField object instead of an array
- Update tests for bidi and server streaming