### PR TITLE
Add array types to MockStubTrait signature

### DIFF
--- a/src/Testing/MockStubTrait.php
+++ b/src/Testing/MockStubTrait.php
@@ -61,8 +61,8 @@ trait MockStubTrait
         $method,
         $argument,
         $deserialize,
-        $metadata = [],
-        $options = []
+        array $metadata = [],
+        array $options = []
     ) {
         if (is_a($argument, '\Google\Protobuf\Internal\Message')) {
             $newArgument = new $argument();


### PR DESCRIPTION
Add array type declarations to match base class https://github.com/grpc/grpc/blob/master/src/php/lib/Grpc/BaseStub.php#L223, which is required by PHP 7