### PR TITLE
Fix DEFAULT keyword in generated protobuf class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 sudo: required
 dist: trusty
 install:
-  - pecl install grpc
+  - travis_retry pecl install grpc
   - composer install
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.xml

--- a/src/generated/Google/Logging/Type/LogSeverity.php
+++ b/src/generated/Google/Logging/Type/LogSeverity.php
@@ -27,7 +27,7 @@ class LogSeverity
      *
      * Generated from protobuf enum <code>DEFAULT = 0;</code>
      */
-    const DEFAULT = 0;
+    const GPBDEFAULT = 0;
     /**
      * (100) Debug or trace information.
      *

--- a/tests/InstantiateClassesTest.php
+++ b/tests/InstantiateClassesTest.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Google\GAX\UnitTests;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RecursiveRegexIterator;
+use RegexIterator;
+
+class InstantiateClassesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider classesProvider
+     */
+    public function testInstantiateProtobufClass($class)
+    {
+        if (strpos($class, 'GrpcClient') !== false) {
+            $instance = new $class('dummyhostname', ['credentials' => null]);
+        } else {
+            $instance = new $class();
+        }
+        $this->assertNotNull($instance);
+    }
+
+    public function classesProvider()
+    {
+        $dir = new RecursiveDirectoryIterator('src/generated/Google');
+        $it = new RecursiveIteratorIterator($dir);
+        $reg = new RegexIterator($it, '#.+\.php$#', RecursiveRegexIterator::GET_MATCH);
+        foreach ($reg as $files) {
+            $file = $files[0];
+            $namespace = str_replace("/", "\\", substr($file, 13));
+            $class = explode('.', $namespace)[0];
+            yield [$class];
+        }
+    }
+}


### PR DESCRIPTION
- Add a test that instantiates all of the generated protobuf classes in src/generated
- Rename instance of invalid DEFAULT keyword