### PR TITLE
make credentials faster

### DIFF
--- a/src/GrpcCredentialsHelper.php
+++ b/src/GrpcCredentialsHelper.php
@@ -130,7 +130,13 @@ class GrpcCredentialsHelper
     {
         $credentialsLoader = $this->args['credentialsLoader'];
         $callback = function () use ($credentialsLoader) {
-            $token = $credentialsLoader->fetchAuthToken();
+            $token = null;
+            if ($this->args['enableCaching']) {
+              $token = $credentialsLoader->getLastReceivedToken();
+            }
+            if (is_null($token) || time() > $token['expires_at']) {
+              $token = $credentialsLoader->fetchAuthToken();
+            }
             return ['authorization' => array('Bearer ' . $token['access_token'])];
         };
         return $callback;

--- a/src/GrpcCredentialsHelper.php
+++ b/src/GrpcCredentialsHelper.php
@@ -132,10 +132,10 @@ class GrpcCredentialsHelper
         $callback = function () use ($credentialsLoader) {
             $token = null;
             if ($this->args['enableCaching']) {
-              $token = $credentialsLoader->getLastReceivedToken();
+                $token = $credentialsLoader->getLastReceivedToken();
             }
             if (is_null($token) || time() > $token['expires_at']) {
-              $token = $credentialsLoader->fetchAuthToken();
+                $token = $credentialsLoader->fetchAuthToken();
             }
             return ['authorization' => array('Bearer ' . $token['access_token'])];
         };

--- a/tests/Mocks/MockCredentialsLoader.php
+++ b/tests/Mocks/MockCredentialsLoader.php
@@ -48,7 +48,7 @@ class MockCredentialsLoader implements FetchAuthTokenInterface
     public function fetchAuthToken(callable $httpHandler = null)
     {
         $this->index = ($this->index + 1) % count($this->tokens);
-        return $this->tokens[$this->index];
+        return $this->toStdToken($this->tokens[$this->index]);
     }
 
     public function getCacheKey()
@@ -61,7 +61,15 @@ class MockCredentialsLoader implements FetchAuthTokenInterface
         if ($this->index == -1) {
             return null;
         } else {
-            return $this->tokens[$this->index];
+            return $this->toStdToken($this->tokens[$this->index]);
         }
+    }
+
+    private function toStdToken($tok)
+    {
+        return [
+            'access_token' => $tok['access_token'],
+            'expires_at' => time() + $tok['expires_in'],
+        ];
     }
 }


### PR DESCRIPTION
The google/auth package provides a general-purpose caching
with FetchAuthTokenCache. The implementation is aimed to be compatible
with PSR-6.

This commit introduces a faster cache, usable in conjuction with
FetchAuthTokenCache.
It queries for the last received token and reuses it if the token has
not expired.
In this way, we avoid sanitizing cache keys and performing table
lookups.

In my testing, this increases our throughput by ~10%.