### PR TITLE
Add in missing httpHandler to fetchAuthToken(..) callback

### DIFF
--- a/src/GrpcCredentialsHelper.php
+++ b/src/GrpcCredentialsHelper.php
@@ -129,8 +129,8 @@ class GrpcCredentialsHelper
     public function createCallCredentialsCallback()
     {
         $credentialsLoader = $this->args['credentialsLoader'];
-        $callback = function () use ($credentialsLoader) {
-            $token = $credentialsLoader->fetchAuthToken();
+        $callback = function (callable $httpHandler = null) use ($credentialsLoader) {
+            $token = $credentialsLoader->fetchAuthToken($httpHandler);
             return ['authorization' => array('Bearer ' . $token['access_token'])];
         };
         return $callback;

--- a/src/GrpcCredentialsHelper.php
+++ b/src/GrpcCredentialsHelper.php
@@ -129,7 +129,7 @@ class GrpcCredentialsHelper
     public function createCallCredentialsCallback()
     {
         $credentialsLoader = $this->args['credentialsLoader'];
-        $callback = function (callable $httpHandler = null) use ($credentialsLoader) {
+        $callback = function ($httpHandler = null) use ($credentialsLoader) {
             $token = $credentialsLoader->fetchAuthToken($httpHandler);
             return ['authorization' => array('Bearer ' . $token['access_token'])];
         };


### PR DESCRIPTION
 Add in missing httpHandler to fetchAuthToken(..) callback generated in createCallCredentialsCallback.

In https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/Core/RequestWrapper.php#L200 the `authHttpHandler` options parameter is passed in. But because the argument is missing at the lambda prototype here, it is not passed to the fetchAuthToken method. Passing `authHttpHandler` is important because it allows production applications to set timeouts and related settings into the fetchAuthToken call like so:

```
$httpHandler = HttpHandlerFactory::build(new GuzzleHttp\Client([
    'timeout' => 1.0,
    'connect_timeout' => 0.3,
    'read_timeout' => 0.7
]);
$client = new SpannerClient([
    'authHttpHandler' => $httpHandler
]);
```

This PR fixes this situation by adding in the parameter to the lambda callback function and `fetchAuthToken(..)` method call.