### PR TITLE
Revert to using ucwords() without the delimiter parameter

### DIFF
--- a/src/CallSettings.php
+++ b/src/CallSettings.php
@@ -236,7 +236,7 @@ class CallSettings
     {
         $camelCaseSettings = [];
         foreach ($settings as $key => $value) {
-            $camelCaseKey = str_replace('_', '', ucwords($key, '_'));
+            $camelCaseKey = str_replace(' ', '', ucwords(str_replace('_', ' ', $key)));
             $camelCaseSettings[lcfirst($camelCaseKey)] = $value;
         }
         return $camelCaseSettings;

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -362,7 +362,7 @@ class Serializer
      */
     public static function toCamelCase($key)
     {
-        return lcfirst(str_replace('_', '', ucwords($key, '_')));
+        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
     }
 
     private static function hasBinaryHeaderSuffix($key)


### PR DESCRIPTION
To support PHP5.5 prior 5.5.16, in which ucwords() does not have the second parameter.