### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "google/protobuf": "^3.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.36",
         "squizlabs/php_codesniffer": "2.*"
     },
     "autoload": {

--- a/src/Testing/GeneratedTest.php
+++ b/src/Testing/GeneratedTest.php
@@ -35,9 +35,9 @@ use Google\GAX\Serializer;
 use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\Internal\Message;
 use Google\Protobuf\Internal\RepeatedField;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class GeneratedTest extends PHPUnit_Framework_TestCase
+class GeneratedTest extends TestCase
 {
 
     public function assertProtobufEquals(&$expected, &$actual)

--- a/src/Testing/LongRunning/MockOperationsImpl.php
+++ b/src/Testing/LongRunning/MockOperationsImpl.php
@@ -49,7 +49,7 @@ use Google\Longrunning\OperationsGrpcClient;
 use Google\Protobuf\Any;
 use Google\Protobuf\GPBEmpty;
 use Grpc;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class MockOperationsImpl extends OperationsGrpcClient

--- a/tests/AgentHeaderDescriptorTest.php
+++ b/tests/AgentHeaderDescriptorTest.php
@@ -32,9 +32,9 @@
 namespace Google\GAX\UnitTests;
 
 use Google\GAX\AgentHeaderDescriptor;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AgentHeaderDescriptorTest extends PHPUnit_Framework_TestCase
+class AgentHeaderDescriptorTest extends TestCase
 {
     public function testWithoutInput()
     {

--- a/tests/ApiCallableTest.php
+++ b/tests/ApiCallableTest.php
@@ -53,9 +53,9 @@ use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
 use Google\Rpc\Code;
 use Google\Rpc\Status;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ApiCallableTest extends PHPUnit_Framework_TestCase
+class ApiCallableTest extends TestCase
 {
     public function testBaseCall()
     {

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -42,10 +42,10 @@ use Google\Rpc\QuotaFailure;
 use Google\Rpc\RequestInfo;
 use Google\Rpc\ResourceInfo;
 use Google\Rpc\RetryInfo;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Grpc;
 
-class ApiExceptionTest extends PHPUnit_Framework_TestCase
+class ApiExceptionTest extends TestCase
 {
     public function testWithoutMetadata()
     {

--- a/tests/ApiStatusTest.php
+++ b/tests/ApiStatusTest.php
@@ -35,10 +35,10 @@ use Exception;
 use Google\GAX\GrpcConstants;
 use Google\GAX\ApiStatus;
 use Google\Rpc\Code;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
-class ApiStatusTest extends PHPUnit_Framework_TestCase
+class ApiStatusTest extends TestCase
 {
     /**
      * @dataProvider getValidStatus

--- a/tests/BidiStreamTest.php
+++ b/tests/BidiStreamTest.php
@@ -38,9 +38,9 @@ use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
 use Grpc;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class BidiStreamTest extends PHPUnit_Framework_TestCase
+class BidiStreamTest extends TestCase
 {
     use TestTrait;
 

--- a/tests/CallSettingsTest.php
+++ b/tests/CallSettingsTest.php
@@ -34,9 +34,9 @@ namespace Google\GAX\UnitTests;
 use Google\GAX\CallSettings;
 use Google\GAX\RetrySettings;
 use Google\GAX\ValidationException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CallSettingsTest extends PHPUnit_Framework_TestCase
+class CallSettingsTest extends TestCase
 {
     const SERVICE_NAME = 'test.interface.v1.api';
 

--- a/tests/ClientStreamTest.php
+++ b/tests/ClientStreamTest.php
@@ -35,9 +35,9 @@ use Google\GAX\ClientStream;
 use Google\GAX\Testing\MockClientStreamingCall;
 use Google\GAX\Testing\MockStatus;
 use Grpc;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ClientStreamTest extends PHPUnit_Framework_TestCase
+class ClientStreamTest extends TestCase
 {
     use TestTrait;
 

--- a/tests/FixedSizeCollectionTest.php
+++ b/tests/FixedSizeCollectionTest.php
@@ -38,10 +38,10 @@ use Google\GAX\Testing\MockStatus;
 use Google\GAX\UnitTests\Mocks\MockStub;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingRequest;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Grpc;
 
-class FixedSizeCollectionTest extends PHPUnit_Framework_TestCase
+class FixedSizeCollectionTest extends TestCase
 {
     private static function createPage($responseSequence)
     {

--- a/tests/GrpcCredentialsHelperTest.php
+++ b/tests/GrpcCredentialsHelperTest.php
@@ -31,11 +31,11 @@
  */
 namespace Google\GAX\UnitTests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Google\GAX\UnitTests\Mocks\MockGrpcCredentialsHelper;
 use Google\GAX\UnitTests\Mocks\MockCredentialsLoader;
 
-class GrpcCredentialsHelperTest extends PHPUnit_Framework_TestCase
+class GrpcCredentialsHelperTest extends TestCase
 {
     private $defaultScope = ['my-scope'];
     private $defaultTokens = [

--- a/tests/InstantiateClassesTest.php
+++ b/tests/InstantiateClassesTest.php
@@ -36,8 +36,9 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
 use RegexIterator;
+use PHPUnit\Framework\TestCase;
 
-class InstantiateClassesTest extends \PHPUnit_Framework_TestCase
+class InstantiateClassesTest extends TestCase
 {
     /**
      * @dataProvider classesProvider

--- a/tests/OperationResponseTest.php
+++ b/tests/OperationResponseTest.php
@@ -36,9 +36,9 @@ use google\longrunning\Operation;
 use Google\GAX\LongRunning\OperationsClient;
 use Google\Protobuf\Any;
 use Google\Rpc\Status;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class OperationResponseTest extends PHPUnit_Framework_TestCase
+class OperationResponseTest extends TestCase
 {
     use TestTrait;
 

--- a/tests/PageStreamingDescriptorTest.php
+++ b/tests/PageStreamingDescriptorTest.php
@@ -32,9 +32,9 @@
 namespace Google\GAX\UnitTests;
 
 use Google\GAX\PageStreamingDescriptor;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PageStreamingDescriptorTest extends PHPUnit_Framework_TestCase
+class PageStreamingDescriptorTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -37,10 +37,10 @@ use Google\GAX\Testing\MockStatus;
 use Google\GAX\UnitTests\Mocks\MockStub;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingRequest;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Grpc;
 
-class PageTest extends PHPUnit_Framework_TestCase
+class PageTest extends TestCase
 {
     private static function createPage($responseSequence)
     {

--- a/tests/PagedListResponseTest.php
+++ b/tests/PagedListResponseTest.php
@@ -36,9 +36,9 @@ use Google\GAX\PageStreamingDescriptor;
 use Google\GAX\UnitTests\Mocks\MockStub;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingRequest;
 use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PagedListResponseTest extends PHPUnit_Framework_TestCase
+class PagedListResponseTest extends TestCase
 {
     public function testNextPageToken()
     {

--- a/tests/PathTemplateTest.php
+++ b/tests/PathTemplateTest.php
@@ -32,9 +32,9 @@
 namespace Google\GAX\UnitTests;
 
 use Google\GAX\PathTemplate;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PathTemplateTest extends PHPUnit_Framework_TestCase
+class PathTemplateTest extends TestCase
 {
     public function testCount()
     {

--- a/tests/ProtobufExtensionTest.php
+++ b/tests/ProtobufExtensionTest.php
@@ -31,9 +31,9 @@
  */
 namespace Google\GAX\UnitTests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ProtobufExtensionTest extends PHPUnit_Framework_TestCase
+class ProtobufExtensionTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/RetrySettingsTest.php
+++ b/tests/RetrySettingsTest.php
@@ -33,9 +33,9 @@ namespace Google\GAX\UnitTests;
 
 use Google\GAX\RetrySettings;
 use Google\GAX\ValidationException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RetrySettingsTest extends PHPUnit_Framework_TestCase
+class RetrySettingsTest extends TestCase
 {
     /**
      * @expectedException \Google\GAX\ValidationException

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -39,11 +39,12 @@ use Google\Protobuf\ListValue;
 use Google\Protobuf\Struct;
 use Google\Protobuf\Value;
 use Google\Rpc\Status;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group core
  */
-class SerializerTest extends \PHPUnit_Framework_TestCase
+class SerializerTest extends TestCase
 {
     /**
      * @param \Google\Protobuf\Internal\Message $message A protobuf message

--- a/tests/ServerStreamTest.php
+++ b/tests/ServerStreamTest.php
@@ -38,9 +38,9 @@ use Google\GAX\UnitTests\Mocks\MockPageStreamingResponse;
 use Google\Protobuf\Internal\GPBType;
 use Google\Protobuf\Internal\RepeatedField;
 use Grpc;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ServerStreamTest extends PHPUnit_Framework_TestCase
+class ServerStreamTest extends TestCase
 {
     use TestTrait;
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.