### PR TITLE
Move transport property from private to protected

### DIFF
--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -48,12 +48,12 @@ trait GapicClientTrait
     use ArrayTrait;
     use ValidationTrait;
 
+    protected $transport;
     private static $gapicVersion;
     private $retrySettings;
     private $serviceName;
     private $agentHeaderDescriptor;
     private $descriptors;
-    private $transport;
     private $transportCallMethods = [
         Call::UNARY_CALL => 'startUnaryCall',
         Call::BIDI_STREAMING_CALL => 'startBidiStreamingCall',

--- a/tests/ApiCore/Tests/Unit/LongRunning/OperationsClientTest.php
+++ b/tests/ApiCore/Tests/Unit/LongRunning/OperationsClientTest.php
@@ -331,7 +331,7 @@ class OperationsClientTest extends GeneratedTest
 
 class MockOperationsClient extends OperationsClient
 {
-    private $transport;
+    protected $transport;
 
     public function __construct($args = [])
     {


### PR DESCRIPTION
This is a bugfix required for the [Spanner GAPIC](https://github.com/GoogleCloudPlatform/google-cloud-php/blob/master/src/Spanner/V1/SpannerClient.php#L50) to expose the transport implementation (used by the session pool to trigger asynchronous delete until official support is built in).