### PR TITLE
Revert "bump API Core version to 0.30.3 (#158)"

### DIFF
--- a/src/ApiCore/AgentHeaderDescriptor.php
+++ b/src/ApiCore/AgentHeaderDescriptor.php
@@ -40,7 +40,7 @@ class AgentHeaderDescriptor
     const AGENT_HEADER_KEY = 'x-goog-api-client';
     // TODO(michaelbausor): include bumping this version in a streamlined
     // release process. Issue: https://github.com/googleapis/gax-php/issues/48
-    const API_CORE_VERSION = '0.30.3';
+    const API_CORE_VERSION = '0.30.2';
     const UNKNOWN_VERSION = '';
 
     private $metricsHeaders;


### PR DESCRIPTION
This reverts commit 0da99ce6e3768e1e69401680cfb3906a2f254d92.