### PR TITLE
Allow PHP7 errors to bubble up

### DIFF
--- a/src/ApiCore/Middleware/RetryMiddleware.php
+++ b/src/ApiCore/Middleware/RetryMiddleware.php
@@ -87,7 +87,7 @@ class RetryMiddleware
             return $nextHandler($call, $options);
         }
 
-        return $nextHandler($call, $options)->then(null, function (Exception $e) use ($call, $options) {
+        return $nextHandler($call, $options)->then(null, function ($e) use ($call, $options) {
             if (!$e instanceof ApiException) {
                 throw $e;
             }


### PR DESCRIPTION
If a dependency throws a PHP7 Error instead of an Exception, this will make sure we bubble that up to our users.