### PR TITLE
Decouple auth and transport

### DIFF
--- a/src/ApiCore/AuthWrapper.php
+++ b/src/ApiCore/AuthWrapper.php
@@ -35,7 +35,7 @@ use DomainException;
 use Exception;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Cache\MemoryCacheItemPool;
-use Google\Auth\FetchAuthTokenCache;
+use Google\Auth\CredentialsLoader;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\HttpHandler\Guzzle5HttpHandler;
 use Google\Auth\HttpHandler\Guzzle6HttpHandler;
@@ -87,7 +87,7 @@ class AuthWrapper
      * @return AuthWrapper
      * @throws ValidationException
      */
-    public static function build(array $args)
+    public static function build(array $args = [])
     {
         $args += [
             'scopes'            => null,
@@ -152,15 +152,19 @@ class AuthWrapper
     }
 
     /**
-     * @param $scopes
-     * @param $authHttpHandler
-     * @param $authCacheOptions
-     * @param $authCache
-     * @return \Google\Auth\CredentialsLoader
+     * @param array $scopes
+     * @param callable $authHttpHandler
+     * @param array $authCacheOptions
+     * @param CacheItemPoolInterface $authCache
+     * @return CredentialsLoader
      * @throws ValidationException
      */
-    private static function buildApplicationDefaultCredentials($scopes, $authHttpHandler, $authCacheOptions, $authCache)
-    {
+    private static function buildApplicationDefaultCredentials(
+        array $scopes = null,
+        callable $authHttpHandler = null,
+        array $authCacheOptions = null,
+        CacheItemPoolInterface $authCache = null
+    ) {
         try {
             return ApplicationDefaultCredentials::getCredentials(
                 $scopes,

--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -197,7 +197,17 @@ trait GapicClientTrait
 
         $descriptors = require($options['descriptorsConfigPath']);
         $this->descriptors = $descriptors['interfaces'][$this->serviceName];
-        $this->authWrapper = AuthWrapper::build($options);
+
+        if (isset($options['credentialsLoader'])) {
+            $authHttpHandler = isset($options['authHttpHandler']) ? $options['authHttpHandler'] : null;
+            $this->authWrapper = new AuthWrapper($options['credentialsLoader'], $authHttpHandler);
+        } else {
+            $this->validateNotNull($options, [
+                'scopes'
+            ]);
+            $this->authWrapper = AuthWrapper::build($options['scopes'], $options);
+        }
+
         $this->transport = $transport instanceof TransportInterface
             ? $transport
             : TransportFactory::build($options);

--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -34,8 +34,12 @@ namespace Google\ApiCore;
 
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Middleware\AgentHeaderMiddleware;
+use Google\ApiCore\Middleware\AuthWrapperMiddleware;
 use Google\ApiCore\Middleware\RetryMiddleware;
 use Google\ApiCore\Transport\TransportInterface;
+use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Auth\FetchAuthTokenCache;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Internal\Message;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -53,6 +57,7 @@ trait GapicClientTrait
     private $retrySettings;
     private $serviceName;
     private $agentHeaderDescriptor;
+    private $authWrapper;
     private $descriptors;
     private $transportCallMethods = [
         Call::UNARY_CALL => 'startUnaryCall',
@@ -192,6 +197,7 @@ trait GapicClientTrait
 
         $descriptors = require($options['descriptorsConfigPath']);
         $this->descriptors = $descriptors['interfaces'][$this->serviceName];
+        $this->authWrapper = AuthWrapper::build($options);
         $this->transport = $transport instanceof TransportInterface
             ? $transport
             : TransportFactory::build($options);
@@ -258,10 +264,13 @@ trait GapicClientTrait
     {
         return new RetryMiddleware(
             new AgentHeaderMiddleware(
-                function (Call $call, array $options) {
-                    $startCallMethod = $this->transportCallMethods[$call->getCallType()];
-                    return $this->transport->$startCallMethod($call, $options);
-                },
+                new AuthWrapperMiddleware(
+                    function (Call $call, array $options) {
+                        $startCallMethod = $this->transportCallMethods[$call->getCallType()];
+                        return $this->transport->$startCallMethod($call, $options);
+                    },
+                    $this->authWrapper
+                ),
                 $this->agentHeaderDescriptor
             ),
             $callConstructionOptions['retrySettings']

--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -37,9 +37,6 @@ use Google\ApiCore\Middleware\AgentHeaderMiddleware;
 use Google\ApiCore\Middleware\AuthWrapperMiddleware;
 use Google\ApiCore\Middleware\RetryMiddleware;
 use Google\ApiCore\Transport\TransportInterface;
-use Google\Auth\Cache\MemoryCacheItemPool;
-use Google\Auth\FetchAuthTokenCache;
-use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\LongRunning\Operation;
 use Google\Protobuf\Internal\Message;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -165,6 +162,7 @@ trait GapicClientTrait
      *     @type string $gapicVersion
      *           The code generator version of the GAPIC library.
      * }
+     * @throws ValidationException
      */
     protected function setClientOptions(array $options)
     {
@@ -202,10 +200,7 @@ trait GapicClientTrait
             $authHttpHandler = isset($options['authHttpHandler']) ? $options['authHttpHandler'] : null;
             $this->authWrapper = new AuthWrapper($options['credentialsLoader'], $authHttpHandler);
         } else {
-            $this->validateNotNull($options, [
-                'scopes'
-            ]);
-            $this->authWrapper = AuthWrapper::build($options['scopes'], $options);
+            $this->authWrapper = AuthWrapper::build($options);
         }
 
         $this->transport = $transport instanceof TransportInterface

--- a/src/ApiCore/Middleware/AuthWrapperMiddleware.php
+++ b/src/ApiCore/Middleware/AuthWrapperMiddleware.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright 2018, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace Google\ApiCore\Middleware;
+
+use Google\ApiCore\AuthWrapper;
+use Google\ApiCore\Call;
+
+/**
+* Middleware which adds an AuthWrapper object to the call options.
+*/
+class AuthWrapperMiddleware
+{
+    /** @var callable */
+    private $nextHandler;
+
+    /** @var AuthWrapper */
+    private $authWrapper;
+
+    public function __construct(
+        callable $nextHandler,
+        AuthWrapper $authWrapper
+    ) {
+        $this->nextHandler = $nextHandler;
+        $this->authWrapper = $authWrapper;
+    }
+
+    public function __invoke(Call $call, array $options)
+    {
+        $next = $this->nextHandler;
+        return $next(
+            $call,
+            $options + ['authWrapper' => $this->authWrapper]
+        );
+    }
+}

--- a/src/ApiCore/Middleware/AuthWrapperMiddleware.php
+++ b/src/ApiCore/Middleware/AuthWrapperMiddleware.php
@@ -47,7 +47,7 @@ class AuthWrapperMiddleware
 
     public function __construct(
         callable $nextHandler,
-        AuthWrapper $authWrapper
+        $authWrapper
     ) {
         $this->nextHandler = $nextHandler;
         $this->authWrapper = $authWrapper;

--- a/src/ApiCore/Middleware/AuthWrapperMiddleware.php
+++ b/src/ApiCore/Middleware/AuthWrapperMiddleware.php
@@ -47,7 +47,7 @@ class AuthWrapperMiddleware
 
     public function __construct(
         callable $nextHandler,
-        $authWrapper
+        AuthWrapper $authWrapper
     ) {
         $this->nextHandler = $nextHandler;
         $this->authWrapper = $authWrapper;

--- a/src/ApiCore/Testing/MockGrpcTransport.php
+++ b/src/ApiCore/Testing/MockGrpcTransport.php
@@ -45,16 +45,11 @@ class MockGrpcTransport extends GrpcTransport
     private $requestArguments;
     private $mockCall;
 
-    public function __construct($mockCall = null, $credentialsLoader = null)
+    public function __construct($mockCall = null)
     {
         $this->mockCall = $mockCall;
-        $credentialsLoader = $credentialsLoader ?: ApplicationDefaultCredentials::getCredentials();
-        $authHttpHandler = function (RequestInterface $request, array $options) {
-            return new Response(200);
-        };
-        $authWrapper = new AuthWrapper($credentialsLoader, $authHttpHandler);
         $opts = ['credentials' => ChannelCredentials::createSsl()];
-        parent::__construct('', $authWrapper, $opts);
+        parent::__construct('', $opts);
     }
 
     protected function _simpleRequest(

--- a/src/ApiCore/Transport/GrpcTransport.php
+++ b/src/ApiCore/Transport/GrpcTransport.php
@@ -157,7 +157,7 @@ class GrpcTransport extends BaseStub implements TransportInterface
             : [];
 
         if (isset($options['authWrapper'])) {
-            $callOptions += ['call_credentials_callback' => $options['authWrapper']->getAuthorizationHeaderCallback()];
+            $callOptions['call_credentials_callback'] = $options['authWrapper']->getAuthorizationHeaderCallback();
         }
 
         if (isset($options['timeoutMillis'])) {

--- a/src/ApiCore/Transport/GrpcTransport.php
+++ b/src/ApiCore/Transport/GrpcTransport.php
@@ -48,22 +48,17 @@ use GuzzleHttp\Promise\Promise;
  */
 class GrpcTransport extends BaseStub implements TransportInterface
 {
-    private $authWrapper;
-
     /**
      * @param string $host The domain name and port of the API remote host.
-     * @param AuthWrapper $authWrapper An AuthWrapper object.
      * @param array $stubOpts An array of options used when creating a BaseStub.
      * @param Channel $channel An already instantiated channel to be used during
      *        creation of the BaseStub.
      */
     public function __construct(
         $host,
-        AuthWrapper $authWrapper,
         array $stubOpts,
         Channel $channel = null
     ) {
-        $this->authWrapper = $authWrapper;
         parent::__construct(
             $host,
             $stubOpts,
@@ -161,7 +156,9 @@ class GrpcTransport extends BaseStub implements TransportInterface
             ? $options['transportOptions']['grpcOptions']
             : [];
 
-        $callOptions += ['call_credentials_callback' => $this->authWrapper->getAuthorizationHeaderCallback()];
+        if (isset($options['authWrapper'])) {
+            $callOptions += ['call_credentials_callback' => $options['authWrapper']->getAuthorizationHeaderCallback()];
+        }
 
         if (isset($options['timeoutMillis'])) {
             $callOptions['timeout'] = $options['timeoutMillis'] * 1000;

--- a/src/ApiCore/Transport/RestTransport.php
+++ b/src/ApiCore/Transport/RestTransport.php
@@ -45,22 +45,18 @@ use Psr\Http\Message\ResponseInterface;
 class RestTransport implements TransportInterface
 {
     private $requestBuilder;
-    private $authWrapper;
     private $httpHandler;
 
     /**
      * @param RequestBuilder $requestBuilder A builder responsible for creating
      *        a PSR-7 request from a set of request information.
-     * @param AuthWrapper $authWrapper An AuthWrapper object.
      * @param callable $httpHandler A handler used to deliver PSR-7 requests.
      */
     public function __construct(
         RequestBuilder $requestBuilder,
-        AuthWrapper $authWrapper,
         callable $httpHandler
     ) {
         $this->requestBuilder = $requestBuilder;
-        $this->authWrapper = $authWrapper;
         $this->httpHandler = $httpHandler;
     }
 
@@ -101,8 +97,8 @@ class RestTransport implements TransportInterface
             : [];
 
         // If not already set, add an auth header to the request
-        if (!isset($headers['Authorization'])) {
-            $headers['Authorization'] = $this->authWrapper->getBearerString();
+        if (!isset($headers['Authorization']) && isset($options['authWrapper'])) {
+            $headers['Authorization'] = $options['authWrapper']->getBearerString();
         }
 
         // call the HTTP handler

--- a/src/ApiCore/TransportFactory.php
+++ b/src/ApiCore/TransportFactory.php
@@ -176,18 +176,6 @@ class TransportFactory
     }
 
     /**
-     * Gets credentials from ADC. This exists to allow overriding in unit tests.
-     *
-     * @param string[] $scopes
-     * @param callable $httpHandler
-     * @return CredentialsLoader
-     */
-    protected static function getADCCredentials(array $scopes, callable $httpHandler)
-    {
-        return ApplicationDefaultCredentials::getCredentials($scopes, $httpHandler);
-    }
-
-    /**
      * Construct ssl channel credentials. This exists to allow overriding in unit tests.
      *
      * @return ChannelCredentials

--- a/src/ApiCore/TransportFactory.php
+++ b/src/ApiCore/TransportFactory.php
@@ -125,8 +125,6 @@ class TransportFactory
 
         $args['transport'] = self::handleTransport($args['transport']);
 
-        $authWrapper = self::buildAuthWrapper($args);
-
         switch ($args['transport']) {
             case 'grpc':
                 if (!self::getGrpcDependencyStatus()) {
@@ -148,7 +146,6 @@ class TransportFactory
 
                 return new GrpcTransport(
                     $host,
-                    $authWrapper,
                     $stubOpts,
                     $args['channel']
                 );
@@ -160,7 +157,6 @@ class TransportFactory
                         $host,
                         $args['restClientConfigPath']
                     ),
-                    $authWrapper,
                     $args['httpHandler'] ?: [HttpHandlerFactory::build(), 'async']
                 );
             default:
@@ -216,39 +212,5 @@ class TransportFactory
             : 'rest';
 
         return $transport;
-    }
-
-    /**
-     * @param array $args
-     * @return AuthWrapper
-     */
-    private static function buildAuthWrapper(array $args)
-    {
-        $authHttpHandler = $args['authHttpHandler'] ?: HttpHandlerFactory::build();
-
-        if (isset($args['credentialsLoader'])) {
-            $credentialsLoader = $args['credentialsLoader'];
-        } else {
-            self::validateNotNull($args, ['scopes']);
-
-            $credentialsLoader = self::getADCCredentials(
-                $args['scopes'],
-                $authHttpHandler
-            );
-
-            if ($args['enableCaching']) {
-                if (!isset($args['authCache'])) {
-                    $args['authCache'] = new MemoryCacheItemPool();
-                }
-
-                $credentialsLoader = new FetchAuthTokenCache(
-                    $credentialsLoader,
-                    $args['authCacheOptions'],
-                    $args['authCache']
-                );
-            }
-        }
-
-        return new AuthWrapper($credentialsLoader, $authHttpHandler);
     }
 }

--- a/tests/ApiCore/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/ApiCore/Tests/Unit/GapicClientTraitTest.php
@@ -68,7 +68,8 @@ class GapicClientTraitTest extends TestCase
              ->with(
                 $this->isInstanceOf(Call::class),
                 $this->equalTo([
-                    'headers' => $expectedHeaders
+                    'headers' => $expectedHeaders,
+                    'authWrapper' => null,
                 ])
             );
         $client = new GapicClientTraitStub();

--- a/tests/ApiCore/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/ApiCore/Tests/Unit/GapicClientTraitTest.php
@@ -33,6 +33,7 @@
 namespace Google\ApiCore\Tests\Unit;
 
 use Google\ApiCore\AgentHeaderDescriptor;
+use Google\ApiCore\AuthWrapper;
 use Google\ApiCore\Call;
 use Google\ApiCore\GapicClientTrait;
 use Google\ApiCore\LongRunning\OperationsClient;
@@ -63,13 +64,14 @@ class GapicClientTraitTest extends TestCase
             'new-header' => ['this-should-be-used'],
         ];
         $transport = $this->getMock(TransportInterface::class);
+        $authWrapper = AuthWrapper::build([]);
         $transport->expects($this->once())
              ->method('startUnaryCall')
              ->with(
                 $this->isInstanceOf(Call::class),
                 $this->equalTo([
                     'headers' => $expectedHeaders,
-                    'authWrapper' => null,
+                    'authWrapper' => $authWrapper,
                 ])
             );
         $client = new GapicClientTraitStub();
@@ -81,6 +83,7 @@ class GapicClientTraitTest extends TestCase
             ]
         );
         $client->set('transport', $transport);
+        $client->set('authWrapper', $authWrapper);
         $client->call('startCall', [
             'method',
             'decodeType',
@@ -104,8 +107,10 @@ class GapicClientTraitTest extends TestCase
         $transport->expects($this->once())
              ->method('startUnaryCall')
              ->will($this->returnValue($expectedPromise));
+        $authWrapper = AuthWrapper::build([]);
         $client = new GapicClientTraitStub();
         $client->set('transport', $transport);
+        $client->set('authWrapper', $authWrapper);
         $client->set('agentHeaderDescriptor', $agentHeaderDescriptor);
         $client->set('retrySettings', ['method' => $retrySettings]);
         $message = new MockRequest();

--- a/tests/ApiCore/Tests/Unit/LongRunning/OperationsClientTest.php
+++ b/tests/ApiCore/Tests/Unit/LongRunning/OperationsClientTest.php
@@ -335,6 +335,7 @@ class MockOperationsClient extends OperationsClient
 
     public function __construct($args = [])
     {
+        $args['scopes'] = [];
         $args['transport'] = new MockTransport;
         $this->transport = $args['transport'];
         parent::__construct($args);

--- a/tests/ApiCore/Tests/Unit/Transport/GrpcTransportTest.php
+++ b/tests/ApiCore/Tests/Unit/Transport/GrpcTransportTest.php
@@ -58,27 +58,12 @@ class GrpcTransportTest extends TestCase
 
     private function callCredentialsCallback(MockGrpcTransport $transport)
     {
-        $mockCall = new Call('method', [], null);
+        $mockCall = new Call('method', '', null);
         $options = [];
 
         $response = $transport->startUnaryCall($mockCall, $options)->wait();
         $args = $transport->getRequestArguments();
         return call_user_func($args['options']['call_credentials_callback']);
-    }
-
-    public function testCustomCredsLoader()
-    {
-        $credentialsLoader = $this->getMock(FetchAuthTokenInterface::class);
-        $credentialsLoader->expects($this->once())
-            ->method('fetchAuthToken')
-            ->willReturn(['access_token' => 'accessToken']);
-        $credentialsLoader->expects($this->once())
-            ->method('getLastReceivedToken')
-            ->willReturn(null);
-
-        $transport = new MockGrpcTransport($this->createMockCall(), $credentialsLoader);
-        $callbackResult = $this->callCredentialsCallback($transport);
-        $this->assertEquals(['Bearer accessToken'], $callbackResult['authorization']);
     }
 
     public function testClientStreamingSuccessObject()

--- a/tests/ApiCore/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/ApiCore/Tests/Unit/Transport/RestTransportTest.php
@@ -72,16 +72,8 @@ class RestTransportTest extends TestCase
         $credentialsLoader->method('fetchAuthToken')
             ->willReturn(['access_token' => 'abc']);
 
-        $authWrapper = new AuthWrapper(
-            $credentialsLoader,
-            function (RequestInterface $request, array $options = []) {
-                return null;
-            }
-        );
-
         return new RestTransport(
             $requestBuilder,
-            $authWrapper,
             $httpHandler
         );
     }
@@ -124,7 +116,7 @@ class RestTransportTest extends TestCase
     }
 
     /**
-     * @expectedException Google\ApiCore\ApiException
+     * @expectedException \Google\ApiCore\ApiException
      */
     public function testStartUnaryCallThrowsRequestException()
     {


### PR DESCRIPTION
This possible change:
- Removes AuthWrapper from the transports, and makes it an option that can be passed to each call
- Adds middleware to inject an AuthWrapper from the client on each call (but as a side benefit, if the user passes one in it won't overwrite, so users can if they want specify an authWrapper per-call)
- Moves AuthWrapper build function into the AuthWrapper class

If we like the high-level idea here, we can then think about moving AuthWrapper out of gax and into the auth library itself. This change could also be cleaned up and submitted independently of the change to update constructor args.