### PR TITLE
Fixes REST ApiExceptions when result is not JSON

### DIFF
--- a/src/ApiCore/ApiException.php
+++ b/src/ApiCore/ApiException.php
@@ -83,19 +83,31 @@ class ApiException extends Exception
     {
         $basicMessage = $status->details;
         $code = $status->code;
-        $rpcStatus = ApiStatus::statusFromRpcCode($code);
         $metadata = property_exists($status, 'metadata') ? $status->metadata : null;
+
+        return self::createFromApiResponse($basicMessage, $code, $metadata);
+    }
+
+    /**
+     * @param string $basicMessage
+     * @param int $rpcCode
+     * @param string|null $metadata
+     * @return ApiException
+     */
+    public static function createFromApiResponse($basicMessage, $rpcCode, $metadata = null)
+    {
+        $rpcStatus = ApiStatus::statusFromRpcCode($rpcCode);
 
         $messageData = [
             'message' => $basicMessage,
-            'code' => $code,
+            'code' => $rpcCode,
             'status' => $rpcStatus,
             'details' => Serializer::decodeMetadata($metadata)
         ];
 
         $message = json_encode($messageData, JSON_PRETTY_PRINT);
 
-        return new ApiException($message, $code, $rpcStatus, [
+        return new ApiException($message, $rpcCode, $rpcStatus, [
             'metadata' => $metadata,
             'basicMessage' => $basicMessage,
         ]);

--- a/src/ApiCore/ApiStatus.php
+++ b/src/ApiCore/ApiStatus.php
@@ -94,6 +94,16 @@ class ApiStatus
         Code::DATA_LOSS => ApiStatus::DATA_LOSS,
         Code::UNAUTHENTICATED => ApiStatus::UNAUTHENTICATED,
     ];
+    private static $httpStatusCodeToRpcCodeMap = [
+        401 => Code::UNAUTHENTICATED,
+        403 => Code::PERMISSION_DENIED,
+        404 => Code::NOT_FOUND,
+        429 => Code::RESOURCE_EXHAUSTED,
+        499 => Code::CANCELLED,
+        501 => Code::UNIMPLEMENTED,
+        503 => Code::UNAVAILABLE,
+        504 => Code::DEADLINE_EXCEEDED,
+    ];
 
     /**
      * @param string $status
@@ -124,6 +134,22 @@ class ApiStatus
     {
         if (array_key_exists($status, self::$apiStatusToCodeMap)) {
             return self::$apiStatusToCodeMap[$status];
+        }
+        return ApiStatus::UNRECOGNIZED_CODE;
+    }
+
+    /**
+     * Maps HTTP status codes to Google\Rpc\Code codes.
+     * Only map codes which do not map to multiple gRPC codes (e.g. excludes
+     * 400, 409, and 500).
+     *
+     * @param int $httpStatusCode
+     * @return int
+     */
+    public static function rpcCodeFromHttpStatusCode($httpStatusCode)
+    {
+        if (array_key_exists($httpStatusCode, self::$httpStatusCodeToRpcCodeMap)) {
+            return self::$httpStatusCodeToRpcCodeMap[$httpStatusCode];
         }
         return ApiStatus::UNRECOGNIZED_CODE;
     }

--- a/src/ApiCore/Transport/RestTransport.php
+++ b/src/ApiCore/Transport/RestTransport.php
@@ -165,12 +165,12 @@ class RestTransport implements TransportInterface
         $res = $ex->getResponse();
         $body = (string) $res->getBody();
         if ($error = json_decode($body, true)['error']) {
-            // Overwrite the HTTP Status Code with the RPC code if it exists.
             $basicMessage = $error['message'];
             $code = ApiStatus::rpcCodeFromStatus($error['status']);
             $metadata = isset($error['details']) ? $error['details'] : null;
             return ApiException::createFromApiResponse($basicMessage, $code, $metadata);
         }
+        // Use the RPC code instead of the HTTP Status Code.
         $code = ApiStatus::rpcCodeFromHttpStatusCode($res->getStatusCode());
         return ApiException::createFromApiResponse($body, $code);
     }

--- a/src/ApiCore/Transport/RestTransport.php
+++ b/src/ApiCore/Transport/RestTransport.php
@@ -36,7 +36,6 @@ use Google\ApiCore\ApiStatus;
 use Google\ApiCore\AuthWrapper;
 use Google\ApiCore\Call;
 use Google\ApiCore\RequestBuilder;
-use Google\ApiCore\Serializer;
 use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\ResponseInterface;
 
@@ -168,41 +167,11 @@ class RestTransport implements TransportInterface
         if ($error = json_decode($body, true)['error']) {
             // Overwrite the HTTP Status Code with the RPC code if it exists.
             $basicMessage = $error['message'];
-            $status = $error['status'];
+            $code = ApiStatus::rpcCodeFromStatus($error['status']);
             $metadata = isset($error['details']) ? $error['details'] : null;
-        } else {
-            // Only map HTTP status codes from Google\Rpc\Code which do not map
-            // to multiple gRPC codes (e.g. excluding 400, 409, and 500).
-            $httpToRpcCodes = [
-                401 => ApiStatus::UNAUTHENTICATED,
-                403 => ApiStatus::PERMISSION_DENIED,
-                404 => ApiStatus::NOT_FOUND,
-                429 => ApiStatus::RESOURCE_EXHAUSTED,
-                499 => ApiStatus::CANCELLED,
-                501 => ApiStatus::UNIMPLEMENTED,
-                503 => ApiStatus::UNAVAILABLE,
-                504 => ApiStatus::DEADLINE_EXCEEDED,
-            ];
-            $status = isset($httpToRpcCodes[$res->getStatusCode()])
-                ? $httpToRpcCodes[$res->getStatusCode()]
-                : ApiStatus::UNKNOWN;
-            $basicMessage = $body;
-            $metadata = null;
+            return ApiException::createFromApiResponse($basicMessage, $code, $metadata);
         }
-
-        $code = ApiStatus::rpcCodeFromStatus($status);
-        $messageData = [
-            'message' => $basicMessage,
-            'status' => $status,
-            'code' => $code,
-            'details' => Serializer::decodeMetadata($metadata)
-        ];
-
-        $message = json_encode($messageData, JSON_PRETTY_PRINT);
-
-        return new ApiException($message, $code, $status, [
-            'metadata' => $metadata,
-            'basicMessage' => $basicMessage,
-        ]);
+        $code = ApiStatus::rpcCodeFromHttpStatusCode($res->getStatusCode());
+        return ApiException::createFromApiResponse($body, $code);
     }
 }

--- a/tests/ApiCore/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/ApiCore/Tests/Unit/Transport/RestTransportTest.php
@@ -142,4 +142,29 @@ class RestTransportTest extends TestCase
             ->startUnaryCall($this->call, [])
             ->wait();
     }
+
+    /**
+     * @expectedException \Google\ApiCore\ApiException
+     * @expectedExceptionMessage <html><body>This is an HTML response<\/body><\/html>
+     * @expectedExceptionCode 5
+     */
+    public function testNonJsonResponseException()
+    {
+        $httpHandler = function (RequestInterface $request, array $options = []) {
+            return Promise\rejection_for(
+                RequestException::create(
+                    new Request('POST', 'http://www.example.com'),
+                    new Response(
+                        404,
+                        [],
+                        "<html><body>This is an HTML response</body></html>"
+                    )
+                )
+            );
+        };
+
+        $this->getTransport($httpHandler)
+            ->startUnaryCall($this->call, [])
+            ->wait();
+    }
 }


### PR DESCRIPTION
This ensures an `ApiException` is properly thrown *even if* the response returned is not in JSON format. For example, 404 messages are HTML.

Without this change, 404 errors generate the following (not helpful) error message: 

```
Google\ApiCore\Tests\Unit\Transport\RestTransportTest::testNonJsonResponseException
Undefined property: stdClass::$status

vendor/google/gax/src/ApiCore/Transport/RestTransport.php:164
vendor/google/gax/src/ApiCore/Transport/RestTransport.php:125
vendor/guzzlehttp/promises/src/RejectedPromise.php:40
vendor/guzzlehttp/promises/src/TaskQueue.php:47
vendor/guzzlehttp/promises/src/Promise.php:246
vendor/guzzlehttp/promises/src/Promise.php:223
vendor/guzzlehttp/promises/src/Promise.php:62
```

With this, the following error is returned:

```
Google\ApiCore\ApiException: {
    "message": "<!DOCTYPE html>\n<html lang=en>\n  <meta charset=utf-8>\n  <meta name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">\n  <title>Error 404 (Not Found)!!1<\/title>\n  <style>\n    *{margin:0;padding:0}html,code{font:15px\/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(\/\/www.google.com\/images\/errors\/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(\/\/www.google.com\/images\/branding\/googlelogo\/1x\/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(\/\/www.google.com\/images\/branding\/googlelogo\/2x\/googlelogo_color_150x54dp.png) no-repeat 0% 0%\/100% 100%;-moz-border-image:url(\/\/www.google.com\/images\/branding\/googlelogo\/2x\/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(\/\/www.google.com\/images\/branding\/googlelogo\/2x\/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n  <\/style>\n  <a href=\/\/www.google.com\/><span id=logo aria-label=Google><\/span><\/a>\n  <p><b>404.<\/b> <ins>That\u2019s an error.<\/ins>\n  <p>The requested URL <code>\/v1beta1\/operations\/us-west1.5745777054394351325<\/code> was not found on this server.  <ins>That\u2019s all we know.<\/ins>\n",
    "code": 5,
    "status": "NOT_FOUND",
    "details": []
}
```