### PR TITLE
Fix Rest calls without placeholders

### DIFF
--- a/src/ApiCore/RequestBuilder.php
+++ b/src/ApiCore/RequestBuilder.php
@@ -77,7 +77,11 @@ class RequestBuilder
             );
         }
 
-        $methodConfig = $this->restConfig['interfaces'][$interface][$method];
+        $methodConfig = $this->restConfig['interfaces'][$interface][$method] + [
+            'placeholders' => [],
+            'body' => null,
+            'additionalBindings' => null,
+        ];
         $bindings = $this->buildBindings($methodConfig['placeholders'], $message);
         $uriTemplateConfigs = $this->getConfigsForUriTemplates($methodConfig);
 
@@ -118,17 +122,11 @@ class RequestBuilder
      */
     private function getConfigsForUriTemplates($config)
     {
-        $configWithDefaults = $config + [
-            'placeholders' => [],
-            'body' => null,
-            'additionalBindings' => null,
-        ];
+        $configs = [$config];
 
-        $configs = [$configWithDefaults];
-
-        if ($configWithDefaults['additionalBindings']) {
-            foreach ($configWithDefaults['additionalBindings'] as $additionalBinding) {
-                $configs[] = $additionalBinding + $configWithDefaults;
+        if ($config['additionalBindings']) {
+            foreach ($config['additionalBindings'] as $additionalBinding) {
+                $configs[] = $additionalBinding + $config;
             }
         }
 

--- a/tests/ApiCore/Tests/Unit/RequestBuilderTest.php
+++ b/tests/ApiCore/Tests/Unit/RequestBuilderTest.php
@@ -223,6 +223,29 @@ class RequestBuilderTest extends TestCase
         $this->assertEquals('some-value', $query['string_value']);
     }
 
+    public function testMethodWithoutPlaceholders()
+    {
+        if (extension_loaded('protobuf')) {
+            $this->markTestSkipped('This is currently broken for the protobuf extension');
+        }
+
+        $stringValue = (new StringValue)
+            ->setValue('some-value');
+
+        $fieldMask = (new FieldMask)
+            ->setPaths(['path1', 'path2']);
+
+        $message = (new MockRequestBody())
+            ->setStringValue($stringValue)
+            ->setFieldMask($fieldMask);
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithoutPlaceholders', $message);
+
+        parse_str($request->getUri()->getQuery(), $query);
+        $this->assertEquals('path1,path2', $query['field_mask']);
+        $this->assertEquals('some-value', $query['string_value']);
+    }
+
     /**
      * @expectedException \Google\ApiCore\ValidationException
      * @expectedExceptionMessage Could not map bindings for test.interface.v1.api/MethodWithAdditionalBindings to any Uri template.

--- a/tests/ApiCore/Tests/Unit/testdata/test_service_rest_client_config.php
+++ b/tests/ApiCore/Tests/Unit/testdata/test_service_rest_client_config.php
@@ -124,6 +124,10 @@ return [
                 'uriTemplate' => '/v1/special/mapping',
                 'placeholders' => []
             ],
+            'MethodWithoutPlaceholders' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/fixedurl',
+            ],
         ],
     ],
 ];


### PR DESCRIPTION
Fix errors caused by default value of `placeholders` not being set before call to `buildBindings`