### PR TITLE
Bump version to 0.31.3 for release

### DIFF
--- a/src/ApiCore/AgentHeaderDescriptor.php
+++ b/src/ApiCore/AgentHeaderDescriptor.php
@@ -40,7 +40,7 @@ class AgentHeaderDescriptor
     const AGENT_HEADER_KEY = 'x-goog-api-client';
     // TODO(michaelbausor): include bumping this version in a streamlined
     // release process. Issue: https://github.com/googleapis/gax-php/issues/48
-    const API_CORE_VERSION = '0.31.1';
+    const API_CORE_VERSION = '0.31.3';
     const UNKNOWN_VERSION = '';
 
     private $metricsHeaders;


### PR DESCRIPTION
Skipping 0.31.2 as that is already tagged: https://github.com/googleapis/gax-php/releases

Note that we are going to release from branch 0.31.x, which pulls in only #166 after 0.31.1