### PR TITLE
Prepare v0.30.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=5.5",
         "google/auth": "^1.2.0",
         "grpc/grpc": "^1.4",
-        "google/protobuf": "^3.5.1",
+        "google/protobuf": "3.5.*",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.2"
     },

--- a/src/ApiCore/AgentHeaderDescriptor.php
+++ b/src/ApiCore/AgentHeaderDescriptor.php
@@ -40,7 +40,7 @@ class AgentHeaderDescriptor
     const AGENT_HEADER_KEY = 'x-goog-api-client';
     // TODO(michaelbausor): include bumping this version in a streamlined
     // release process. Issue: https://github.com/googleapis/gax-php/issues/48
-    const API_CORE_VERSION = '0.30.2';
+    const API_CORE_VERSION = '0.30.3';
     const UNKNOWN_VERSION = '';
 
     private $metricsHeaders;


### PR DESCRIPTION
## Google ApiCore 0.30.3

### Pin to protobuf 3.5.*
- Pin to protobuf version 3.5.* to avoid breakage caused by https://github.com/google/protobuf/issues/4738 (#184)
