### PR TITLE
Prepare 0.31.4

### DIFF
--- a/src/ApiCore/AgentHeaderDescriptor.php
+++ b/src/ApiCore/AgentHeaderDescriptor.php
@@ -40,7 +40,7 @@ class AgentHeaderDescriptor
     const AGENT_HEADER_KEY = 'x-goog-api-client';
     // TODO(michaelbausor): include bumping this version in a streamlined
     // release process. Issue: https://github.com/googleapis/gax-php/issues/48
-    const API_CORE_VERSION = '0.31.3';
+    const API_CORE_VERSION = '0.31.4';
     const UNKNOWN_VERSION = '';
 
     private $metricsHeaders;


### PR DESCRIPTION
## Google ApiCore 0.31.4

### Pin to protobuf 3.5.*
- Pin to protobuf version 3.5.* to avoid breakage caused by https://github.com/google/protobuf/issues/4738 (#189)
