### PR TITLE
Make CredentialsWrapper protected

### DIFF
--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -59,11 +59,13 @@ trait GapicClientTrait
     /** @access private */
     protected $transport;
 
+    /** @access private */
+    protected $credentialsWrapper;
+
     private static $gapicVersion;
     private $retrySettings;
     private $serviceName;
     private $agentHeaderDescriptor;
-    private $credentialsWrapper;
     private $descriptors;
     private $transportCallMethods = [
         Call::UNARY_CALL => 'startUnaryCall',

--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -56,10 +56,7 @@ trait GapicClientTrait
     use ValidationTrait;
     use GrpcSupportTrait;
 
-    /** @access private */
     protected $transport;
-
-    /** @access private */
     protected $credentialsWrapper;
 
     private static $gapicVersion;
@@ -83,6 +80,30 @@ trait GapicClientTrait
     public function close()
     {
         $this->transport->close();
+    }
+
+    /**
+     * Get the transport for the client. This method is protected to support
+     * use by customized clients.
+     *
+     * @access private
+     * @return TransportInterface
+     */
+    protected function getTransport()
+    {
+        return $this->transport;
+    }
+
+    /**
+     * Get the credentials for the client. This method is protected to support
+     * use by customized clients.
+     *
+     * @access private
+     * @return CredentialsWrapper
+     */
+    protected function getCredentialsWrapper()
+    {
+        return $this->credentialsWrapper;
     }
 
     private static function getGapicVersion(array $options)

--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -56,8 +56,8 @@ trait GapicClientTrait
     use ValidationTrait;
     use GrpcSupportTrait;
 
-    protected $transport;
-    protected $credentialsWrapper;
+    private $transport;
+    private $credentialsWrapper;
 
     private static $gapicVersion;
     private $retrySettings;

--- a/tests/ApiCore/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/ApiCore/Tests/Unit/GapicClientTraitTest.php
@@ -635,6 +635,24 @@ class GapicClientTraitTest extends TestCase
             ],
         ];
     }
+
+    public function testGetTransport()
+    {
+        $transport = $this->getMock(TransportInterface::class);
+        $client = new GapicClientTraitStub();
+        $client->set('transport', $transport);
+        $this->assertEquals($transport, $client->call('getTransport'));
+    }
+
+    public function testGetCredentialsWrapper()
+    {
+        $credentialsWrapper = $this->getMockBuilder(CredentialsWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client = new GapicClientTraitStub();
+        $client->set('credentialsWrapper', $credentialsWrapper);
+        $this->assertEquals($credentialsWrapper, $client->call('getCredentialsWrapper'));
+    }
 }
 
 class GapicClientTraitStub


### PR DESCRIPTION
Make CredentialsWrapper protected in GapicClientTrait. We have received a request to make this available from other teams using the generated clients.