### PR TITLE
Preparatory refactoring to add grpc-fallback support

### DIFF
--- a/src/ApiCore/ApiException.php
+++ b/src/ApiCore/ApiException.php
@@ -96,8 +96,12 @@ class ApiException extends Exception
      * @param \Exception $previous
      * @return ApiException
      */
-    public static function createFromApiResponse($basicMessage, $rpcCode, $metadata = null, $previous = null)
-    {
+    public static function createFromApiResponse(
+        $basicMessage,
+        $rpcCode,
+        array $metadata = null,
+        \Exception $previous = null
+    ) {
         $rpcStatus = ApiStatus::statusFromRpcCode($rpcCode);
 
         $messageData = [

--- a/src/ApiCore/Transport/GuzzleTransportTrait.php
+++ b/src/ApiCore/Transport/GuzzleTransportTrait.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ * Copyright 2018, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace Google\ApiCore\Transport;
+
+use Exception;
+use Google\ApiCore\Call;
+use Google\ApiCore\ValidationException;
+use Google\Auth\HttpHandler\HttpHandlerFactory;
+
+/**
+ * An trait for shared functionality between Guzzle HTTP-based transports.
+ */
+trait GuzzleTransportTrait
+{
+    private $httpHandler;
+    private $transportName;
+
+    /**
+     * {@inheritdoc}
+     * @throws \BadMethodCallException
+     */
+    public function startClientStreamingCall(Call $call, array $options)
+    {
+        $this->throwUnsupportedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \BadMethodCallException
+     */
+    public function startServerStreamingCall(Call $call, array $options)
+    {
+        $this->throwUnsupportedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \BadMethodCallException
+     */
+    public function startBidiStreamingCall(Call $call, array $options)
+    {
+        $this->throwUnsupportedException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        // Nothing to do.
+    }
+
+    /**
+     * @param array $options
+     * @return array
+     */
+    private static function buildCommonHeaders(array $options)
+    {
+        $headers = isset($options['headers'])
+            ? $options['headers']
+            : [];
+
+        // If not already set, add an auth header to the request
+        if (!isset($headers['Authorization']) && isset($options['credentialsWrapper'])) {
+            $headers['Authorization'] = $options['credentialsWrapper']->getBearerString();
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @return callable
+     * @throws ValidationException
+     */
+    private static function buildHttpHandlerAsync()
+    {
+        try {
+            return [HttpHandlerFactory::build(), 'async'];
+        } catch (Exception $ex) {
+            throw new ValidationException("Failed to build HttpHandler", $ex->getCode(), $ex);
+        }
+    }
+
+    private function throwUnsupportedException()
+    {
+        throw new \BadMethodCallException(
+            "Streaming calls are not supported while using the {$this->transportName} transport."
+        );
+    }
+}

--- a/src/ApiCore/Transport/HttpUnaryTransportTrait.php
+++ b/src/ApiCore/Transport/HttpUnaryTransportTrait.php
@@ -37,9 +37,10 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 
 /**
- * An trait for shared functionality between Guzzle HTTP-based transports.
+ * An trait for shared functionality between transports that support only unary RPCs using simple
+ * HTTP requests/
  */
-trait GuzzleTransportTrait
+trait HttpUnaryTransportTrait
 {
     private $httpHandler;
     private $transportName;

--- a/src/ApiCore/Transport/HttpUnaryTransportTrait.php
+++ b/src/ApiCore/Transport/HttpUnaryTransportTrait.php
@@ -37,8 +37,8 @@ use Google\ApiCore\ValidationException;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 
 /**
- * An trait for shared functionality between transports that support only unary RPCs using simple
- * HTTP requests/
+ * A trait for shared functionality between transports that support only unary RPCs using simple
+ * HTTP requests.
  */
 trait HttpUnaryTransportTrait
 {

--- a/src/ApiCore/Transport/RestTransport.php
+++ b/src/ApiCore/Transport/RestTransport.php
@@ -48,7 +48,7 @@ class RestTransport implements TransportInterface
 {
     use ValidationTrait;
     use ServiceAddressTrait;
-    use GuzzleTransportTrait;
+    use HttpUnaryTransportTrait;
 
     private $requestBuilder;
 


### PR DESCRIPTION
This PR is intended to prepare the ground for adding support for the grpc-fallback transport (serial protobuf over HTTP 1.1). It:
- Adds ApiException::createFromRpcStatus
- Refactors functionality from RestTransport into GuzzleTransportTrait
- No behaviour changes