### PR TITLE
Support empty or null access tokens

### DIFF
--- a/src/ApiCore/CredentialsWrapper.php
+++ b/src/ApiCore/CredentialsWrapper.php
@@ -141,7 +141,12 @@ class CredentialsWrapper
      */
     public function getBearerString()
     {
-        return 'Bearer ' . self::getToken($this->credentialsFetcher, $this->authHttpHandler);
+        $token = self::getToken($this->credentialsFetcher, $this->authHttpHandler);
+        if (isset($token)) {
+            return "Bearer $token";
+        } else {
+            return '';
+        }
     }
 
     /**
@@ -156,7 +161,12 @@ class CredentialsWrapper
         // be passed into the gRPC c extension, and changes have the potential to trigger very
         // difficult-to-diagnose segmentation faults.
         return function () use ($credentialsFetcher, $authHttpHandler) {
-            return ['authorization' => ['Bearer ' . self::getToken($credentialsFetcher, $authHttpHandler)]];
+            $token = self::getToken($credentialsFetcher, $authHttpHandler);
+            if (isset($token)) {
+                return ['authorization' => ["Bearer $token"]];
+            } else {
+                return [];
+            }
         };
     }
 

--- a/src/ApiCore/CredentialsWrapper.php
+++ b/src/ApiCore/CredentialsWrapper.php
@@ -142,10 +142,10 @@ class CredentialsWrapper
     public function getBearerString()
     {
         $token = self::getToken($this->credentialsFetcher, $this->authHttpHandler);
-        if (isset($token)) {
-            return "Bearer $token";
-        } else {
+        if (empty($token)) {
             return '';
+        } else {
+            return "Bearer $token";
         }
     }
 
@@ -162,10 +162,10 @@ class CredentialsWrapper
         // difficult-to-diagnose segmentation faults.
         return function () use ($credentialsFetcher, $authHttpHandler) {
             $token = self::getToken($credentialsFetcher, $authHttpHandler);
-            if (isset($token)) {
-                return ['authorization' => ["Bearer $token"]];
-            } else {
+            if (empty($token)) {
                 return [];
+            } else {
+                return ['authorization' => ["Bearer $token"]];
             }
         };
     }

--- a/src/ApiCore/CredentialsWrapper.php
+++ b/src/ApiCore/CredentialsWrapper.php
@@ -142,11 +142,7 @@ class CredentialsWrapper
     public function getBearerString()
     {
         $token = self::getToken($this->credentialsFetcher, $this->authHttpHandler);
-        if (empty($token)) {
-            return '';
-        } else {
-            return "Bearer $token";
-        }
+        return empty($token) ? '' : "Bearer $token";
     }
 
     /**
@@ -162,11 +158,7 @@ class CredentialsWrapper
         // difficult-to-diagnose segmentation faults.
         return function () use ($credentialsFetcher, $authHttpHandler) {
             $token = self::getToken($credentialsFetcher, $authHttpHandler);
-            if (empty($token)) {
-                return [];
-            } else {
-                return ['authorization' => ["Bearer $token"]];
-            }
+            return empty($token) ? [] : ['authorization' => ["Bearer $token"]];
         };
     }
 

--- a/src/ApiCore/GapicClientTrait.php
+++ b/src/ApiCore/GapicClientTrait.php
@@ -315,28 +315,28 @@ trait GapicClientTrait
     }
 
     /**
-     * @param mixed $auth
-     * @param array $authConfig
+     * @param mixed $credentials
+     * @param array $credentialsConfig
      * @return CredentialsWrapper
      * @throws ValidationException
      */
-    private function createCredentialsWrapper($auth, array $authConfig)
+    private function createCredentialsWrapper($credentials, array $credentialsConfig)
     {
-        if (is_null($auth)) {
-            return CredentialsWrapper::build($authConfig);
-        } elseif (is_string($auth) || is_array($auth)) {
-            return CredentialsWrapper::build(['keyFile' => $auth] + $authConfig);
-        } elseif ($auth instanceof FetchAuthTokenInterface) {
-            $authHttpHandler = isset($authConfig['authHttpHandler'])
-                ? $authConfig['authHttpHandler']
+        if (is_null($credentials)) {
+            return CredentialsWrapper::build($credentialsConfig);
+        } elseif (is_string($credentials) || is_array($credentials)) {
+            return CredentialsWrapper::build(['keyFile' => $credentials] + $credentialsConfig);
+        } elseif ($credentials instanceof FetchAuthTokenInterface) {
+            $authHttpHandler = isset($credentialsConfig['authHttpHandler'])
+                ? $credentialsConfig['authHttpHandler']
                 : null;
-            return new CredentialsWrapper($auth, $authHttpHandler);
-        } elseif ($auth instanceof CredentialsWrapper) {
-            return $auth;
+            return new CredentialsWrapper($credentials, $authHttpHandler);
+        } elseif ($credentials instanceof CredentialsWrapper) {
+            return $credentials;
         } else {
             throw new ValidationException(
                 'Unexpected value in $auth option, got: ' .
-                print_r($auth, true)
+                print_r($credentials, true)
             );
         }
     }

--- a/src/ApiCore/Transport/HttpUnaryTransportTrait.php
+++ b/src/ApiCore/Transport/HttpUnaryTransportTrait.php
@@ -92,7 +92,10 @@ trait HttpUnaryTransportTrait
 
         // If not already set, add an auth header to the request
         if (!isset($headers['Authorization']) && isset($options['credentialsWrapper'])) {
-            $headers['Authorization'] = $options['credentialsWrapper']->getBearerString();
+            $bearerString = $options['credentialsWrapper']->getBearerString();
+            if (!empty($bearerString)) {
+                $headers['Authorization'] = $bearerString;
+            }
         }
 
         return $headers;

--- a/tests/ApiCore/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/ApiCore/Tests/Unit/CredentialsWrapperTest.php
@@ -179,9 +179,23 @@ class CredentialsWrapperTest extends TestCase
                 'access_token' => 123,
                 'expires_at' => time() + 100,
             ]);
+        $insecureFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $insecureFetcher->getLastReceivedToken()->willReturn(null);
+        $insecureFetcher->fetchAuthToken(Argument::any())
+            ->willReturn([
+                'access_token' => '',
+            ]);
+        $nullFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $nullFetcher->getLastReceivedToken()->willReturn(null);
+        $nullFetcher->fetchAuthToken(Argument::any())
+            ->willReturn([
+                'access_token' => null,
+            ]);
         return [
             [$expiredFetcher->reveal(), 'Bearer 456'],
             [$unexpiredFetcher->reveal(), 'Bearer 123'],
+            [$insecureFetcher->reveal(), ''],
+            [$nullFetcher->reveal(), '']
         ];
     }
 
@@ -215,9 +229,24 @@ class CredentialsWrapperTest extends TestCase
                 'access_token' => 123,
                 'expires_at' => time() + 100,
             ]);
+
+        $insecureFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $insecureFetcher->getLastReceivedToken()->willReturn(null);
+        $insecureFetcher->fetchAuthToken(Argument::any())
+            ->willReturn([
+                'access_token' => '',
+            ]);
+        $nullFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $nullFetcher->getLastReceivedToken()->willReturn(null);
+        $nullFetcher->fetchAuthToken(Argument::any())
+            ->willReturn([
+                'access_token' => null,
+            ]);
         return [
             [$expiredFetcher->reveal(), ['authorization' => ['Bearer 456']]],
             [$unexpiredFetcher->reveal(), ['authorization' => ['Bearer 123']]],
+            [$insecureFetcher->reveal(), []],
+            [$nullFetcher->reveal(), []],
         ];
     }
 }


### PR DESCRIPTION
Handle and test for empty or null access tokens, which may be returned by insecure/anonymous credentials.