### PR TITLE
Update interceptor interface to match grpc

### DIFF
--- a/src/Transport/Grpc/UnaryInterceptorInterface.php
+++ b/src/Transport/Grpc/UnaryInterceptorInterface.php
@@ -43,6 +43,7 @@ interface UnaryInterceptorInterface
     /**
      * @param $method
      * @param $argument
+     * @param $deserialize
      * @param array $metadata
      * @param array $options
      * @param callable $continuation
@@ -51,6 +52,7 @@ interface UnaryInterceptorInterface
     public function interceptUnaryUnary(
         $method,
         $argument,
+        $deserialize,
         array $metadata,
         array $options,
         callable $continuation

--- a/src/Transport/GrpcTransport.php
+++ b/src/Transport/GrpcTransport.php
@@ -189,13 +189,14 @@ class GrpcTransport extends BaseStub implements TransportInterface
         return function (
             $method,
             $argument,
+            $deserialize,
             array $metadata = [],
             array $options = []
         ) use (
             $execute,
             $interceptor
         ) {
-            return $interceptor->interceptUnaryUnary($method, $argument, $metadata, $options, $execute);
+            return $interceptor->interceptUnaryUnary($method, $argument, $deserialize, $metadata, $options, $execute);
         };
     }
 
@@ -206,8 +207,7 @@ class GrpcTransport extends BaseStub implements TransportInterface
         array $metadata = [],
         array $options = []
     ) {
-    
-        $execute = function ($method, $argument, $metadata, array $options) use ($deserialize) {
+        $execute = function ($method, $argument, $deserialize, $metadata, $options) {
             return parent::_simpleRequest(
                 $method,
                 $argument,
@@ -220,7 +220,7 @@ class GrpcTransport extends BaseStub implements TransportInterface
             $execute  = $this->wrapExecuteWithInterceptor($execute, $interceptor);
         }
 
-        return $execute($method, $argument, $metadata, $options);
+        return $execute($method, $argument, $deserialize, $metadata, $options);
     }
 
     /**


### PR DESCRIPTION
- Adds a deserialize argument to the UnaryInterceptorInterface::interceptUnaryUnary method to match the grpc interface: https://github.com/grpc/grpc/blob/master/src/php/lib/Grpc/Interceptor.php#L30
- Adds a test for the interceptor

cc @fiboknacky