### PR TITLE
Loosen conflict to protobuf v3.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: PROTOBUF_C_EXT=true
     - php: '7.2'
       install:
-      - travis_retry pecl install protobuf-3.7.0
+      - travis_retry pecl install protobuf-3.6.1
       script:
       - ./dev/sh/test-composer-conflict.sh
     - stage: 'deploy'

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "sami/sami": "*"
     },
     "conflict": {
-        "ext-protobuf": "<3.7.1"
+        "ext-protobuf": "<3.7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Addresses: https://github.com/googleapis/google-cloud-php/issues/1805

This should be reverted once we have protobuf v3.7.1 available on app engine.