### PR TITLE
Fix JSON empty object encoding

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -103,7 +103,7 @@ class RequestBuilder
                     $config['method'],
                     $uri,
                     ['Content-Type' => 'application/json'] + $headers,
-                    $body ? json_encode($body) : null
+                    $body
                 );
             }
         }
@@ -145,15 +145,15 @@ class RequestBuilder
      */
     private function constructBodyAndQueryParameters(Message $message, $config)
     {
-        $messageData = json_decode($message->serializeToJsonString(), true);
+        $messageDataJson = $message->serializeToJsonString();
 
         if ($config['body'] === '*') {
-            return [$messageData, []];
+            return [$messageDataJson, []];
         }
 
         $body = null;
         $queryParams = [];
-
+        $messageData = json_decode($messageDataJson, true);
         foreach ($messageData as $name => $value) {
             if (array_key_exists($name, $config['placeholders'])) {
                 continue;
@@ -173,7 +173,7 @@ class RequestBuilder
             }
         }
 
-        return [$body, $queryParams];
+        return [$body ? json_encode($body) : null, $queryParams];
     }
 
     /**

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -160,7 +160,11 @@ class RequestBuilder
             }
 
             if (Serializer::toSnakeCase($name) === $config['body']) {
-                $body = $message->{"get$name"}()->serializeToJsonString();
+                if (($bodyMessage = $message->{"get$name"}()) instanceof Message) {
+                    $body = $bodyMessage->serializeToJsonString();
+                } else {
+                    $body = json_encode($value);
+                }
                 continue;
             }
 

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -160,7 +160,7 @@ class RequestBuilder
             }
 
             if (Serializer::toSnakeCase($name) === $config['body']) {
-                $body = $value;
+                $body = $message->{"get$name"}()->serializeToJsonString();
                 continue;
             }
 
@@ -173,7 +173,7 @@ class RequestBuilder
             }
         }
 
-        return [$body ? json_encode($body) : null, $queryParams];
+        return [$body, $queryParams];
     }
 
     /**

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -97,6 +97,19 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testMethodWithScalarBody()
+    {
+        $message = new MockRequestBody();
+        $message->setName('foo');
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithScalarBody', $message);
+
+        $this->assertEquals(
+            '"foo"',
+            (string) $request->getBody()
+        );
+    }
+
     public function testMethodWithEmptyMessageInBody()
     {
         $message = new MockRequestBody();

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -97,6 +97,22 @@ class RequestBuilderTest extends TestCase
         );
     }
 
+    public function testMethodWithEmptyNestedMessageAsBody()
+    {
+        $message = new MockRequestBody();
+        $message->setName('message/foo');
+        $nestedMessage = new MockRequestBody();
+        $nestedMessage->setName('');
+        $message->setNestedMessage($nestedMessage);
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBody', $message);
+
+        $this->assertEquals(
+            '{"name":"message\/foo","nestedMessage":{}}',
+            (string) $request->getBody()
+        );
+    }
+
     public function testMethodWithNestedUrlPlaceholder()
     {
         $message = new MockRequestBody();

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -97,18 +97,36 @@ class RequestBuilderTest extends TestCase
         );
     }
 
-    public function testMethodWithEmptyNestedMessageAsBody()
+    public function testMethodWithEmptyMessageInBody()
     {
         $message = new MockRequestBody();
         $message->setName('message/foo');
         $nestedMessage = new MockRequestBody();
-        $nestedMessage->setName('');
         $message->setNestedMessage($nestedMessage);
 
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBody', $message);
 
         $this->assertEquals(
             '{"name":"message\/foo","nestedMessage":{}}',
+            (string) $request->getBody()
+        );
+    }
+
+    public function testMethodWithEmptyMessageInNestedMessageBody()
+    {
+        $message = new MockRequestBody();
+        $message->setName('message/foo');
+        $nestedMessage = new MockRequestBody();
+        $nestedMessage->setName('nested/foo');
+        $message->setNestedMessage($nestedMessage);
+        $emptyMessage = new MockRequestBody();
+        $nestedMessage->setNestedMessage($emptyMessage);
+
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithNestedMessageAsBody', $message);
+
+        $this->assertEquals(
+            '{"name":"nested\/foo","nestedMessage":{}}',
             (string) $request->getBody()
         );
     }

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -67,7 +67,7 @@ class RequestBuilderTest extends TestCase
         $nestedMessage->setName('nested/foo');
         $message->setNestedMessage($nestedMessage);
 
-        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBody', $message);
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBodyAndUrlPlaceholder', $message);
         $uri = $request->getUri();
 
         $this->assertEmpty($uri->getQuery());
@@ -100,15 +100,14 @@ class RequestBuilderTest extends TestCase
     public function testMethodWithEmptyMessageInBody()
     {
         $message = new MockRequestBody();
-        $message->setName('message/foo');
         $nestedMessage = new MockRequestBody();
         $message->setNestedMessage($nestedMessage);
 
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBody', $message);
 
         $this->assertEquals(
-            '{"name":"message\/foo","nestedMessage":{}}',
-            (string) $request->getBody()
+            '{"nestedMessage":{}}',
+            $request->getBody()
         );
     }
 
@@ -117,7 +116,6 @@ class RequestBuilderTest extends TestCase
         $message = new MockRequestBody();
         $message->setName('message/foo');
         $nestedMessage = new MockRequestBody();
-        $nestedMessage->setName('nested/foo');
         $message->setNestedMessage($nestedMessage);
         $emptyMessage = new MockRequestBody();
         $nestedMessage->setNestedMessage($emptyMessage);
@@ -126,8 +124,8 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithNestedMessageAsBody', $message);
 
         $this->assertEquals(
-            '{"name":"nested\/foo","nestedMessage":{}}',
-            (string) $request->getBody()
+            '{"nestedMessage":{}}',
+            $request->getBody()
         );
     }
 

--- a/tests/Tests/Unit/testdata/test_service_rest_client_config.php
+++ b/tests/Tests/Unit/testdata/test_service_rest_client_config.php
@@ -3,6 +3,11 @@
 return [
     'interfaces' => [
         'test.interface.v1.api' => [
+            'MethodWithBody' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/foo',
+                'body' => '*',
+            ],
             'MethodWithUrlPlaceholder' => [
                 'method' => 'get',
                 'uriTemplate' => '/v1/{name=message/**}',
@@ -14,7 +19,7 @@ return [
                     ],
                 ],
             ],
-            'MethodWithBody' => [
+            'MethodWithBodyAndUrlPlaceholder' => [
                 'method' => 'post',
                 'uriTemplate' => '/v1/{name=message/**}',
                 'body' => '*',

--- a/tests/Tests/Unit/testdata/test_service_rest_client_config.php
+++ b/tests/Tests/Unit/testdata/test_service_rest_client_config.php
@@ -43,6 +43,11 @@ return [
                     ],
                 ],
             ],
+            'MethodWithScalarBody' => [
+                'method' => 'post',
+                'uriTemplate' => '/v1/foo',
+                'body' => 'name',
+            ],
             'MethodWithNestedUrlPlaceholder' => [
                 'method' => 'get',
                 'uriTemplate' => '/v1/{nested_message=nested/**}',


### PR DESCRIPTION
A request with an empty Message object is being JSON encoded as an array `[]` instead of object `{}`. For instance, this request:

```php
$message = new MockRequestBody();
$message->setName('message/foo');
$anotherMessage = new MockRequestBody();
$message->setNestedMessage($anotherMessage);
```

will output this:

```json
{"name":"message\/foo","nestedMessage":[]}
```
when it should output this:

```json
{"name":"message\/foo","nestedMessage":{}}
```

This fix will work when `body = *` in the rest client config, but will not work if the `body` is a property of the message.

**EDIT**: Added fix so it works when body is a property of the message