### PR TITLE
Disable service config resolution by default

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -172,6 +172,7 @@ trait GapicClientTrait
         $options['credentialsConfig'] += $defaultOptions['credentialsConfig'];
         $options['transportConfig'] += $defaultOptions['transportConfig'];
         $options['transportConfig']['grpc'] += $defaultOptions['transportConfig']['grpc'];
+        $options['transportConfig']['grpc']['stubOpts'] += $defaultOptions['transportConfig']['grpc']['stubOpts'];
         $options['transportConfig']['rest'] += $defaultOptions['transportConfig']['rest'];
         $options['transportConfig']['grpc-fallback'] += $defaultOptions['transportConfig']['grpc-fallback'];
 

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -160,7 +160,7 @@ trait GapicClientTrait
             'libVersion' => null,
         ];
         $defaultOptions['transportConfig'] += [
-            'grpc' => [],
+            'grpc' => ['stubOpts' => ['grpc.service_config_disable_resolution' => 1]],
             'rest' => [],
             'grpc-fallback' => [],
         ];

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -403,7 +403,8 @@ class GapicClientTraitTest extends TestCase
             'transportConfig' => [
                 'grpc' => [
                     'stubOpts' => [
-                        'grpc_call_invoker' => $grpcGcpConfig->callInvoker()
+                        'grpc_call_invoker' => $grpcGcpConfig->callInvoker(),
+                        'grpc.service_config_disable_resolution' => 1
                     ]
                 ],
                 'rest' => [


### PR DESCRIPTION
Disables resolution of the gRPC ServiceConfig from DNS TXT Records. Context https://github.com/googleapis/gapic-generator/issues/2778.