### PR TITLE
Add file exists check to gax readVersionFile method

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -56,7 +56,9 @@ class Version
      */
     public static function readVersionFile($file)
     {
-        $versionString = @file_get_contents($file) ?: "";
+        $versionString = file_exists($file)
+            ? file_get_contents($file)
+            : "";
         return trim($versionString);
     }
 


### PR DESCRIPTION
Fixes #243.

The existing method suppresses error output, but if a custom error handler is enabled, it will catch the warning. This change adds a `file_exists()` check to prevent attempting to read a non-existent file.