### PR TITLE
fix: Properly format grpc metadata keys for non-ASCII values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ jobs:
     - php: '7.2'
     - php: '7.2'
       env: PROTOBUF_C_EXT=true
+    - php: '7.3'
+    - php: '7.3'
+      env: PROTOBUF_C_EXT=true
     - php: '7.2'
       install:
       - travis_retry pecl install protobuf-3.6.1
@@ -42,4 +45,3 @@ script:
   - if [[ $TRAVIS_PHP_VERSION =~ ^7 ]]; then ./dev/sh/build-docs.sh; fi
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-

--- a/src/RequestParamsHeaderDescriptor.php
+++ b/src/RequestParamsHeaderDescriptor.php
@@ -38,6 +38,10 @@ namespace Google\ApiCore;
 class RequestParamsHeaderDescriptor
 {
     const HEADER_KEY = 'x-goog-request-params';
+
+    /**
+     * @var array
+     */
     private $header;
 
     /**
@@ -48,6 +52,8 @@ class RequestParamsHeaderDescriptor
      */
     public function __construct($requestParams)
     {
+        $headerKey = self::HEADER_KEY;
+
         $headerValue = '';
         foreach ($requestParams as $key => $value) {
             if ('' !== $headerValue) {
@@ -55,7 +61,14 @@ class RequestParamsHeaderDescriptor
             }
             $headerValue .= $key . '=' . strval($value);
         }
-        $this->header = [self::HEADER_KEY => [$headerValue]];
+
+        // If the value contains non-ASCII characters, suffix the header key with `-bin`.
+        // see https://grpc.github.io/grpc/python/glossary.html#term-metadata
+        if (preg_match('/[^\x00-\x7F]/', $headerValue) !== 0) {
+            $headerKey = $headerKey . '-bin';
+        }
+
+        $this->header = [$headerKey => [$headerValue]];
     }
 
     /**

--- a/tests/Tests/Unit/RequestParamsHeaderDescriptorTest.php
+++ b/tests/Tests/Unit/RequestParamsHeaderDescriptorTest.php
@@ -71,4 +71,17 @@ class RequestParamsHeaderDescriptorTest extends TestCase
 
         $this->assertSame($expectedHeader, $header);
     }
+
+    public function testNonAsciiChars()
+    {
+        $val = 'こんにちは';
+        $expectedHeader = [
+            RequestParamsHeaderDescriptor::HEADER_KEY . '-bin' => ['field1=' . $val]
+        ];
+
+        $agentHeaderDescriptor = new RequestParamsHeaderDescriptor(['field1' => $val]);
+        $header = $agentHeaderDescriptor->getHeader();
+
+        $this->assertSame($expectedHeader, $header);
+    }
 }

--- a/tests/Tests/Unit/RequestParamsHeaderDescriptorTest.php
+++ b/tests/Tests/Unit/RequestParamsHeaderDescriptorTest.php
@@ -72,7 +72,7 @@ class RequestParamsHeaderDescriptorTest extends TestCase
         $this->assertSame($expectedHeader, $header);
     }
 
-    public function testNonAsciiChars()
+    public function testNonAsciiCharsAppendsBinToHeaderKey()
     {
         $val = 'こんにちは';
         $expectedHeader = [


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-php/issues/2297.