### PR TITLE
feat: ignore unknown fields by default

### DIFF
--- a/src/Transport/RestTransport.php
+++ b/src/Transport/RestTransport.php
@@ -115,7 +115,8 @@ class RestTransport implements TransportInterface
                 /** @var Message $return */
                 $return = new $decodeType;
                 $return->mergeFromJsonString(
-                    (string) $response->getBody()
+                    (string) $response->getBody(),
+                    true
                 );
 
                 if (isset($options['metadataCallback'])) {


### PR DESCRIPTION
This flag will ensure we don't throw exceptions with the rest transport when dealing with unknown enum fields. Please see https://github.com/protocolbuffers/protobuf/pull/7455/files for the protobuf implementation.