### PR TITLE
feat: default to self-signed JWTs and use updateMetadata for fetching tokens

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -190,11 +190,11 @@ class CredentialsWrapper
         // be passed into the gRPC c extension, and changes have the potential to trigger very
         // difficult-to-diagnose segmentation faults.
 
-        return function () use ($credentialsFetcher, $authHttpHandler, $audience) {
+        return function (array $headers = []) use ($credentialsFetcher, $authHttpHandler, $audience) {
             $token = $credentialsFetcher->getLastReceivedToken();
             if (self::isExpired($token)) {
                 if ($credentialsFetcher instanceof UpdateMetadataInterface) {
-                    return $credentialsFetcher->updateMetadata([], $audience);
+                    return $credentialsFetcher->updateMetadata($headers, $audience);
                 }
                 $token = $credentialsFetcher->fetchAuthToken($authHttpHandler);
                 if (!self::isValid($token)) {
@@ -202,7 +202,10 @@ class CredentialsWrapper
                 }
             }
             $tokenString = $token['access_token'];
-            return empty($tokenString) ? [] : ['authorization' => ["Bearer $tokenString"]];
+            if (!empty($tokenString)) {
+                $headers['authorization'] = ["Bearer $tokenString"];
+            }
+            return $headers;
         };
     }
 

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -193,9 +193,13 @@ class CredentialsWrapper
         return function (array $headers = []) use ($credentialsFetcher, $authHttpHandler, $audience) {
             $token = $credentialsFetcher->getLastReceivedToken();
             if (self::isExpired($token)) {
+                // Call updateMetadata to take advantage of self-signed JWTs
                 if ($credentialsFetcher instanceof UpdateMetadataInterface) {
                     return $credentialsFetcher->updateMetadata($headers, $audience);
                 }
+
+                // In case a custom fetcher is provided (unlikely) which doesn't
+                // implement UpdateMetadataInterface
                 $token = $credentialsFetcher->fetchAuthToken($authHttpHandler);
                 if (!self::isValid($token)) {
                     return [];

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -187,8 +187,7 @@ trait GapicClientTrait
 
         // If an API endpoint is set, ensure the "audience" does not conflict
         // with the custom endpoint by setting "user defined" scopes.
-        if (
-            $options['apiEndpoint'] != $defaultOptions['apiEndpoint']
+        if ($options['apiEndpoint'] != $defaultOptions['apiEndpoint']
             && empty($options['credentialsConfig']['scopes'])
             && !empty($options['credentialsConfig']['defaultScopes'])
         ) {

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -49,6 +49,7 @@ use Google\Protobuf\Internal\Message;
 use Grpc\Gcp\ApiConfig;
 use Grpc\Gcp\Config;
 use GuzzleHttp\Promise\PromiseInterface;
+use LogicException;
 
 /**
  * Common functions used to work with various clients.
@@ -181,6 +182,18 @@ trait GapicClientTrait
         // serviceAddress is now deprecated and acts as an alias for apiEndpoint
         if (isset($options['serviceAddress'])) {
             $options['apiEndpoint'] = $this->pluck('serviceAddress', $options, false);
+        }
+
+        // If an API endpoint is set, ensure the "audience" does not conflict
+        // with the custom endpoint by setting "user defined" scopes.
+        if (
+            isset($options['apiEndpoint'])
+            && isset($defaultOptions['apiEndpoint'])
+            && $options['apiEndpoint'] != $defaultOptions['apiEndpoint']
+            && empty($options['credentialsConfig']['scopes'])
+            && !empty($options['credentialsConfig']['defaultScopes'])
+        ) {
+            $options['credentialsConfig']['scopes'] = $options['credentialsConfig']['defaultScopes'];
         }
 
         if (extension_loaded('sysvshm')
@@ -471,7 +484,9 @@ trait GapicClientTrait
                 break;
         }
 
-        return $callStack($call, $optionalArgs);
+        return $callStack($call, $optionalArgs + array_filter([
+            'audience' => self::getDefaultAudience()
+        ]));
     }
 
     /**
@@ -505,6 +520,7 @@ trait GapicClientTrait
             'timeoutMillis',
             'transportOptions',
             'metadataCallback',
+            'audience',
         ]);
 
         return $callStack;
@@ -628,6 +644,17 @@ trait GapicClientTrait
             $interfaceName ?: $this->serviceName,
             $methodName
         );
+    }
+
+    /**
+     * The SERVICE_ADDRESS constant is set by GAPIC clients
+     */
+    private static function getDefaultAudience()
+    {
+        if (!defined('self::SERVICE_ADDRESS')) {
+            return null;
+        }
+        return 'https://' . self::SERVICE_ADDRESS . '/';
     }
 
     // Gapic Client Extension Points

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -159,6 +159,7 @@ trait GapicClientTrait
             'gapicVersion' => self::getGapicVersion($options),
             'libName' => null,
             'libVersion' => null,
+            'apiEndpoint' => null,
         ];
         $defaultOptions['transportConfig'] += [
             'grpc' => ['stubOpts' => ['grpc.service_config_disable_resolution' => 1]],
@@ -187,9 +188,7 @@ trait GapicClientTrait
         // If an API endpoint is set, ensure the "audience" does not conflict
         // with the custom endpoint by setting "user defined" scopes.
         if (
-            isset($options['apiEndpoint'])
-            && isset($defaultOptions['apiEndpoint'])
-            && $options['apiEndpoint'] != $defaultOptions['apiEndpoint']
+            $options['apiEndpoint'] != $defaultOptions['apiEndpoint']
             && empty($options['credentialsConfig']['scopes'])
             && !empty($options['credentialsConfig']['defaultScopes'])
         ) {

--- a/src/Transport/GrpcTransport.php
+++ b/src/Transport/GrpcTransport.php
@@ -241,8 +241,12 @@ class GrpcTransport extends BaseStub implements TransportInterface
             : [];
 
         if (isset($options['credentialsWrapper'])) {
+            $audience = isset($options['audience'])
+                ? $options['audience']
+                : null;
             $credentialsWrapper = $options['credentialsWrapper'];
-            $callOptions['call_credentials_callback'] = $credentialsWrapper->getAuthorizationHeaderCallback();
+            $callOptions['call_credentials_callback'] = $credentialsWrapper
+                ->getAuthorizationHeaderCallback($audience);
         }
 
         if (isset($options['timeoutMillis'])) {

--- a/src/Transport/HttpUnaryTransportTrait.php
+++ b/src/Transport/HttpUnaryTransportTrait.php
@@ -92,10 +92,13 @@ trait HttpUnaryTransportTrait
 
         // If not already set, add an auth header to the request
         if (!isset($headers['Authorization']) && isset($options['credentialsWrapper'])) {
-            $bearerString = $options['credentialsWrapper']->getBearerString();
-            if (!empty($bearerString)) {
-                $headers['Authorization'] = $bearerString;
-            }
+            $credentialsWrapper = $options['credentialsWrapper'];
+            $audience = isset($options['audience'])
+                ? $options['audience']
+                : null;
+            $callback = $credentialsWrapper
+                ->getAuthorizationHeaderCallback($audience);
+            $headers = $callback($headers);
         }
 
         return $headers;

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -250,6 +250,14 @@ class CredentialsWrapperTest extends TestCase
             ]);
         $expiredFetcher->updateMetadata(Argument::any(), 'audience')
             ->willReturn(['authorization' => ['Bearer 456']]);
+        $expiredInvalidFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $expiredInvalidFetcher->getLastReceivedToken()
+            ->willReturn([
+                'access_token' => 123,
+                'expires_at' => time() - 1
+            ]);
+        $expiredInvalidFetcher->fetchAuthToken(Argument::any())
+            ->willReturn(['not-a' => 'valid-token']);
         $unexpiredFetcher = $this->prophesize();
         $unexpiredFetcher->willImplement(FetchAuthTokenInterface::class);
         $unexpiredFetcher->getLastReceivedToken()
@@ -282,6 +290,7 @@ class CredentialsWrapperTest extends TestCase
 
         return [
             [$expiredFetcher->reveal(), ['authorization' => ['Bearer 456']]],
+            [$expiredInvalidFetcher->reveal(), []],
             [$unexpiredFetcher->reveal(), ['authorization' => ['Bearer 123']]],
             [$insecureFetcher->reveal(), []],
             [$nullFetcher->reveal(), []],

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -258,24 +258,18 @@ class CredentialsWrapperTest extends TestCase
                 'expires_at' => time() + 100,
             ]);
 
-        $insecureFetcher = $this->prophesize();
-        $insecureFetcher->willImplement(FetchAuthTokenInterface::class);
-        $insecureFetcher->willImplement(UpdateMetadataInterface::class);
-        $insecureFetcher->getLastReceivedToken()
+        $insecureFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $insecureFetcher->getLastReceivedToken()->willReturn(null);
+        $insecureFetcher->fetchAuthToken(Argument::any())
             ->willReturn([
                 'access_token' => '',
             ]);
-        $insecureFetcher->updateMetadata(Argument::any(), 'audience')
-            ->willReturn([]);
-        $nullFetcher = $this->prophesize();
-        $nullFetcher->willImplement(FetchAuthTokenInterface::class);
-        $nullFetcher->willImplement(UpdateMetadataInterface::class);
-        $nullFetcher->getLastReceivedToken()
+        $nullFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $nullFetcher->getLastReceivedToken()->willReturn(null);
+        $nullFetcher->fetchAuthToken(Argument::any())
             ->willReturn([
                 'access_token' => null,
             ]);
-        $nullFetcher->updateMetadata(Argument::any(), 'audience')
-            ->willReturn([]);
 
         $customFetcher = $this->prophesize();
         $customFetcher->willImplement(FetchAuthTokenInterface::class);

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -750,6 +750,86 @@ class GapicClientTraitTest extends TestCase
             'decodeType'
         ]);
     }
+
+    public function testDefaultScopes()
+    {
+        $client = new GapicClientTraitDefaultScopeAndAudienceStub();
+
+        // verify scopes are not set by default
+        $defaultOptions = $client->call('buildClientOptions', [[]]);
+        $this->assertArrayNotHasKey('scopes', $defaultOptions['credentialsConfig']);
+
+        // verify scopes are set when a custom api endpoint is used
+        $defaultOptions = $client->call('buildClientOptions', [[
+            'apiEndpoint' => 'www.someotherendpoint.com',
+        ]]);
+        $this->assertArrayHasKey('scopes', $defaultOptions['credentialsConfig']);
+        $this->assertEquals(
+            $client::$serviceScopes,
+            $defaultOptions['credentialsConfig']['scopes']
+        );
+
+        // verify user-defined scopes override default scopes
+        $defaultOptions = $client->call('buildClientOptions', [[
+            'credentialsConfig' => ['scopes' => ['user-scope-1']],
+            'apiEndpoint' => 'www.someotherendpoint.com',
+        ]]);
+        $this->assertArrayHasKey('scopes', $defaultOptions['credentialsConfig']);
+        $this->assertEquals(
+            ['user-scope-1'],
+            $defaultOptions['credentialsConfig']['scopes']
+        );
+
+        // verify empty default scopes has no effect
+        $client::$serviceScopes = null;
+        $defaultOptions = $client->call('buildClientOptions', [[
+            'apiEndpoint' => 'www.someotherendpoint.com',
+        ]]);
+        $this->assertArrayNotHasKey('scopes', $defaultOptions['credentialsConfig']);
+    }
+
+    public function testDefaultAudience()
+    {
+        $retrySettings = $this->prophesize(RetrySettings::class);
+        $credentialsWrapper = $this->prophesize(CredentialsWrapper::class)
+            ->reveal();
+        $transport = $this->prophesize(TransportInterface::class);
+        $transport
+            ->startUnaryCall(
+                Argument::any(),
+                [
+                    'audience' => 'https://service-address/',
+                    'headers' => [],
+                    'credentialsWrapper' => $credentialsWrapper,
+                ]
+            )
+            ->shouldBeCalledOnce();
+
+        $client = new GapicClientTraitDefaultScopeAndAudienceStub();
+        $client->set('credentialsWrapper', $credentialsWrapper);
+        $client->set('agentHeader', []);
+        $client->set(
+            'retrySettings',
+            ['method.name' => $retrySettings->reveal()]
+        );
+        $client->set('transport', $transport->reveal());
+        $client->call('startCall', ['method.name', 'decodeType']);
+
+        $transport
+            ->startUnaryCall(
+                Argument::any(),
+                [
+                    'audience' => 'custom-audience',
+                    'headers' => [],
+                    'credentialsWrapper' => $credentialsWrapper,
+                ]
+            )
+            ->shouldBeCalledOnce();
+
+        $client->call('startCall', ['method.name', 'decodeType', [
+            'audience' => 'custom-audience',
+        ]]);
+    }
 }
 
 class GapicClientTraitStub
@@ -831,5 +911,44 @@ class GapicClientTraitStubExtension extends GapicClientTraitStub
             ];
             return $originalCallable($call, $options);
         };
+    }
+}
+
+class GapicClientTraitDefaultScopeAndAudienceStub
+{
+    use GapicClientTrait;
+
+    const SERVICE_ADDRESS = 'service-address';
+
+    public static $serviceScopes = [
+        'default-scope-1',
+        'default-scope-2',
+    ];
+
+    public static function getClientDefaults()
+    {
+        return [
+            'apiEndpoint' => 'test.address.com:443',
+            'credentialsConfig' => [
+                'defaultScopes' => self::$serviceScopes,
+            ],
+        ];
+    }
+
+    public function call($fn, array $args = [])
+    {
+        return call_user_func_array([$this, $fn], $args);
+    }
+
+    public function set($name, $val, $static = false)
+    {
+        if (!property_exists($this, $name)) {
+            throw new \InvalidArgumentException("Property not found: $name");
+        }
+        if ($static) {
+            $this::$$name = $val;
+        } else {
+            $this->$name = $val;
+        }
     }
 }

--- a/tests/Tests/Unit/Transport/GrpcTransportTest.php
+++ b/tests/Tests/Unit/Transport/GrpcTransportTest.php
@@ -377,16 +377,12 @@ class GrpcTransportTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider buildDataGrpc
-     */
     public function testAudienceOption()
     {
-        $message = $this->prophesize(Message::class);
-        $message->serializeToString()->willReturn('');
+        $message = $this->createMockRequest();
 
         $call = $this->prophesize(Call::class);
-        $call->getMessage()->willReturn($message->reveal());
+        $call->getMessage()->willReturn($message);
         $call->getMethod()->shouldBeCalled();
         $call->getDecodeType()->shouldBeCalled();
 

--- a/tests/Tests/Unit/Transport/GrpcTransportTest.php
+++ b/tests/Tests/Unit/Transport/GrpcTransportTest.php
@@ -33,6 +33,7 @@
 namespace Google\ApiCore\Tests\Unit\Transport;
 
 use Google\ApiCore\Call;
+use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\Tests\Unit\TestTrait;
 use Google\ApiCore\Testing\MockGrpcTransport;
 use Google\ApiCore\Testing\MockRequest;
@@ -374,6 +375,32 @@ class GrpcTransportTest extends TestCase
         foreach ($stream->closeWriteAndReadAll() as $actualResponse) {
             // for loop to trigger generator and API exception
         }
+    }
+
+    /**
+     * @dataProvider buildDataGrpc
+     */
+    public function testAudienceOption()
+    {
+        $message = $this->prophesize(Message::class);
+        $message->serializeToString()->willReturn('');
+
+        $call = $this->prophesize(Call::class);
+        $call->getMessage()->willReturn($message->reveal());
+        $call->getMethod()->shouldBeCalled();
+        $call->getDecodeType()->shouldBeCalled();
+
+        $credentialsWrapper = $this->prophesize(CredentialsWrapper::class);
+        $credentialsWrapper->getAuthorizationHeaderCallback('an-audience')
+            ->shouldBeCalledOnce();
+        $hostname = '';
+        $opts = ['credentials' => ChannelCredentials::createInsecure()];
+        $transport = new GrpcTransport($hostname, $opts);
+        $options = [
+            'audience' => 'an-audience',
+            'credentialsWrapper' => $credentialsWrapper->reveal(),
+        ];
+        $transport->startUnaryCall($call->reveal(), $options);
     }
 
     /**


### PR DESCRIPTION
This PR implements changes to allow the GAPIC clients to default to self-signed JWTs by doing the following:

1. Adds `defaultScopes` option for GAPIC clients
1. Uses `updateMetadata` instead of `fetchAuthToken` in `CredentialsWrapper` in order to take advantage of the self-signed JWT logic in `google/auth`
1. When the `SERVICE_ADDRESS` constant is defined, the Gapic clients pass this through the auth library as the `$authUri` when fetching an access token.
1. Calls `getAuthorizationHeaderCallback` in `RestTransport` for consistency
1. Deprecates `getBearerString` in favor of `getAuthorizationHeaderCallback`

No behavior should be impacted until we roll out `defaultScope` config values in Gapic clients.

**Important**
Depends on https://github.com/googleapis/google-auth-library-php/pull/306
Will require the updating minimum version of `google/auth` 
