### PR TITLE
tests: namespace fixes

### DIFF
--- a/tests/Tests/Unit/PageStreamingDescriptorTest.php
+++ b/tests/Tests/Unit/PageStreamingDescriptorTest.php
@@ -35,7 +35,7 @@ use Google\ApiCore\PageStreamingDescriptor;
 use Google\Rpc\Code;
 use PHPUnit\Framework\TestCase;
 
-class ApiTest extends TestCase
+class PageStreamingDescriptorTest extends TestCase
 {
     use TestTrait;
 

--- a/tests/Tests/Unit/ResourceTemplate/AbsoluteResourceTemplateTest.php
+++ b/tests/Tests/Unit/ResourceTemplate/AbsoluteResourceTemplateTest.php
@@ -29,7 +29,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-namespace Google\ApiCore\Tests\Unit;
+namespace Google\ApiCore\Tests\Unit\ResourceTemplate;
 
 use Google\ApiCore\ResourceTemplate\AbsoluteResourceTemplate;
 use PHPUnit\Framework\TestCase;

--- a/tests/Tests/Unit/ResourceTemplate/ParserTest.php
+++ b/tests/Tests/Unit/ResourceTemplate/ParserTest.php
@@ -29,7 +29,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-namespace Google\ApiCore\Tests\Unit;
+namespace Google\ApiCore\Tests\Unit\ResourceTemplate;
 
 use Google\ApiCore\ResourceTemplate\Parser;
 use Google\ApiCore\ResourceTemplate\RelativeResourceTemplate;

--- a/tests/Tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
+++ b/tests/Tests/Unit/ResourceTemplate/RelativeResourceTemplateTest.php
@@ -29,7 +29,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-namespace Google\ApiCore\Tests\Unit;
+namespace Google\ApiCore\Tests\Unit\ResourceTemplate;
 
 use Google\ApiCore\ResourceTemplate\RelativeResourceTemplate;
 use PHPUnit\Framework\TestCase;

--- a/tests/Tests/Unit/Transport/Grpc/ForwardingServerStreamCallTest.php
+++ b/tests/Tests/Unit/Transport/Grpc/ForwardingServerStreamCallTest.php
@@ -37,7 +37,7 @@ use Google\ApiCore\Transport\Grpc\ForwardingServerStreamingCall;
 use Grpc\ServerStreamingCall;
 use PHPUnit\Framework\TestCase;
 
-class ForwardingServerStreamingCallTest extends TestCase
+class ForwardingServerStreamCallTest extends TestCase
 {
     use TestTrait;
 


### PR DESCRIPTION
Follows up on https://github.com/googleapis/gax-php/pull/278 addressing concerns as a result of running `composer install --optimize-autoloader`.