### PR TITLE
fix: Do not pass headers to credentials callback

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -189,8 +189,7 @@ class CredentialsWrapper
         // NOTE: changes to this function should be treated carefully and tested thoroughly. It will
         // be passed into the gRPC c extension, and changes have the potential to trigger very
         // difficult-to-diagnose segmentation faults.
-
-        return function (array $headers = []) use ($credentialsFetcher, $authHttpHandler, $audience) {
+        return function () use ($credentialsFetcher, $authHttpHandler, $audience) {
             $token = $credentialsFetcher->getLastReceivedToken();
             if (self::isExpired($token)) {
                 // Call updateMetadata to take advantage of self-signed JWTs
@@ -207,9 +206,9 @@ class CredentialsWrapper
             }
             $tokenString = $token['access_token'];
             if (!empty($tokenString)) {
-                $headers['authorization'] = ["Bearer $tokenString"];
+                return ['authorization' => ["Bearer $tokenString"]];
             }
-            return $headers;
+            return [];
         };
     }
 

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -194,7 +194,7 @@ class CredentialsWrapper
             if (self::isExpired($token)) {
                 // Call updateMetadata to take advantage of self-signed JWTs
                 if ($credentialsFetcher instanceof UpdateMetadataInterface) {
-                    return $credentialsFetcher->updateMetadata($headers, $audience);
+                    return $credentialsFetcher->updateMetadata([], $audience);
                 }
 
                 // In case a custom fetcher is provided (unlikely) which doesn't

--- a/src/Transport/HttpUnaryTransportTrait.php
+++ b/src/Transport/HttpUnaryTransportTrait.php
@@ -98,7 +98,10 @@ trait HttpUnaryTransportTrait
                 : null;
             $callback = $credentialsWrapper
                 ->getAuthorizationHeaderCallback($audience);
-            $headers = $callback($headers);
+            // Prevent unexpected behavior, as the authorization header callback
+            // uses lowercase "authorization"
+            unset($headers['authorization']);
+            $headers += $callback();
         }
 
         return $headers;

--- a/tests/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/Tests/Unit/Transport/RestTransportTest.php
@@ -248,7 +248,7 @@ class RestTransportTest extends TestCase
         $credentialsWrapper = $this->prophesize(CredentialsWrapper::class);
         $credentialsWrapper->getAuthorizationHeaderCallback('an-audience')
             ->shouldBeCalledOnce()
-            ->willReturn(function($headers) { return []; });
+            ->willReturn(function() { return []; });
 
         $options = [
             'audience' => 'an-audience',


### PR DESCRIPTION
gRPC already passes an argument to the credentials callback, and it's a stdObj with `service_url` and `method_name` properties. So we cannot use this parameter, and we don't need to.