### PR TITLE
chore: codeowners replace actools w/actools-php

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/actools @googleapis/yoshi-php
+*     @googleapis/actools-php @googleapis/yoshi-php


### PR DESCRIPTION
Narrows down CODEOWNER `actools` to `actools-php`.