### PR TITLE
chore: cleanup build-docs script

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,9 @@ jobs:
         steps:
         - name: Checkout
           uses: actions/checkout@v2
-        - uses: olegtarasov/get-tag@v2
-          id: tagName
+        - id: getTag
+          name: Get Tag
+          run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
         - name: Install composer dependencies
           uses: nick-invision/retry@v1
           with:
@@ -22,7 +23,7 @@ jobs:
           uses: docker://php:7.2-cli
           with:
             entrypoint: ./dev/sh/build-docs.sh
-            args: ${{ steps.tagName.outputs.tag }}
+            args: ${{ steps.getTag.outputs.tag }}
         - run: |
             git submodule add -q -f -b gh-pages https://github.com/${{github.repository}} ghpages
             rsync -aP tmp_gh-pages/* ghpages/

--- a/dev/sh/build-docs.sh
+++ b/dev/sh/build-docs.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
 # Script to build doc site.
-# This script expects to be invoked from the gax-php root.
-#
-# This script will look for the GITHUB_REF environment variable, and
-# use that as the version number. If no environment variable is found,
-# it will use the first command line argument. If no command line
-# argument is specified, default to 'master'.
+# This script expects to be invoked from the gax-php root. It requires a git tag
+# as the first argument.
 
 set -ev
 
@@ -21,11 +17,6 @@ GIT_TAG_NAME=$1
 ROOT_DIR=$(pwd)
 DOC_OUTPUT_DIR=${ROOT_DIR}/tmp_gh-pages
 DOCTUM_EXECUTABLE=${ROOT_DIR}/doctum.phar
-
-UPDATED_INDEX_FILE=$(cat << EndOfMessage
-<html><head><script>window.location.replace('/gax-php/${GIT_TAG_NAME}/' + location.hash.substring(1))</script></head><body></body></html>
-EndOfMessage
-)
 
 function downloadDoctum() {
   # Download the latest (5.1.x) release
@@ -52,24 +43,17 @@ function checkVersionFile() {
 }
 
 function buildDocs() {
-  DOCS_VERSION_TO_BUILD=${1}
   DOCTUM_CONFIG=${ROOT_DIR}/dev/src/Docs/doctum-config.php
-  API_CORE_DOCS_VERSION=${DOCS_VERSION_TO_BUILD} php ${DOCTUM_EXECUTABLE} update ${DOCTUM_CONFIG} -v
+  API_CORE_DOCS_VERSION=${GIT_TAG_NAME} php ${DOCTUM_EXECUTABLE} update ${DOCTUM_CONFIG} -v
 }
 
 downloadDoctum
-if [[ ! -z ${GIT_TAG_NAME} ]]; then
-  checkVersionFile ${GIT_TAG_NAME}
-  buildDocs ${GIT_TAG_NAME}
-  # Update the redirect index file only for builds that use the
-  # GIT_TAG_NAME env variable.
-  echo ${UPDATED_INDEX_FILE} > ${DOC_OUTPUT_DIR}/index.html
-else
-  if [[ ! -z ${1} ]]; then
-    DOCS_VERSION_TO_BUILD=${1}
-  else
-    # If no command line arg is specified, default to 'master'
-    DOCS_VERSION_TO_BUILD=master
-  fi
-  buildDocs ${DOCS_VERSION_TO_BUILD}
-fi
+checkVersionFile ${GIT_TAG_NAME}
+buildDocs ${GIT_TAG_NAME}
+
+# Construct the base index file to redirect to the latest version of the docs.
+UPDATED_INDEX_FILE=$(cat << EndOfMessage
+<html><head><script>window.location.replace('/gax-php/${GIT_TAG_NAME}/' + location.hash.substring(1))</script></head><body></body></html>
+EndOfMessage
+)
+echo ${UPDATED_INDEX_FILE} > ${DOC_OUTPUT_DIR}/index.html


### PR DESCRIPTION
 - More accurate comments
 - Removes codepaths for when arguments are not present, which no longer exist
 - Misc refactor