### PR TITLE
fix: alias "validate" in GapicClientTrait 

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -57,7 +57,9 @@ use LogicException;
 trait GapicClientTrait
 {
     use ArrayTrait;
-    use ValidationTrait;
+    use ValidationTrait {
+        ValidationTrait::validate as traitValidate;
+    }
     use GrpcSupportTrait;
 
     /** @var TransportInterface */
@@ -298,7 +300,7 @@ trait GapicClientTrait
             'credentialsConfig',
             'transportConfig',
         ]);
-        $this->validate($options, [
+        $this->traitValidate($options, [
             'credentials',
             'transport',
             'gapicVersion',


### PR DESCRIPTION
Alias the "validate" function in `GapicClientTrait` to prevent conflict with generated validate method. This prevents errors for generated GAPIC clients which contain a `validate` method.

Here is an example of what this is meant to address from the upcoming Compute GAPIC:

```php
class UrlMapsGapicClient
{
    use GapicClientTrait;

    //...

    public function validate($project, $urlMap, array $optionalArgs = [])
    {
        $request = new ValidateUrlMapRequest();
        $request->setProject($project);
        $request->setUrlMap($urlMap);
        if (isset($optionalArgs['urlMapsValidateRequestResource'])) {
            $request->setUrlMapsValidateRequestResource($optionalArgs['urlMapsValidateRequestResource']);
        }

        return $this->startCall(
            'Validate',
            UrlMapsValidateResponse::class,
            $optionalArgs,
            $request
        )->wait();
    }
}
```