### PR TITLE
fix: remove handling of deadline_exceeded delay

### DIFF
--- a/src/Middleware/RetryMiddleware.php
+++ b/src/Middleware/RetryMiddleware.php
@@ -127,10 +127,6 @@ class RetryMiddleware
             );
         }
 
-        // Don't sleep if the failure was a timeout
-        if ($status != ApiStatus::DEADLINE_EXCEEDED) {
-            usleep($delayMs * 1000);
-        }
         $delayMs = min($delayMs * $delayMult, $maxDelayMs);
         $timeoutMs = min(
             $timeoutMs * $timeoutMult,


### PR DESCRIPTION
https://github.com/googleapis/gax-java/issues/591 states that _not_ imposing attempt delay when retrying a timed out RPC could worsen overload outages, a common source of client timeout issues. The relevant code was removed in https://github.com/googleapis/gax-java/pull/597.

I found that similar code existed in gax-php, and with no other language doing something similar still that I could find, I figured it should be removed.