### PR TITLE
Allow CredentialsWrapper to use the auth cache when fetching ADC.

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -121,8 +121,8 @@ class CredentialsWrapper
             $loader = self::buildApplicationDefaultCredentials(
                 $args['scopes'],
                 $authHttpHandler,
-                null,
-                null,
+                $args['authCacheOptions'],
+                $args['authCache'],
                 $args['quotaProject'],
                 $args['defaultScopes']
             );


### PR DESCRIPTION
Motivation: This lets us cache the result of `ApplicationDefaultCredentials::onGce()`, saving us a ping to the metadata server.

Let me know if I'm missing something, or if there was a good reason to provide `null`.