### PR TITLE
feat: add logical timeout helper to RetrySettings

### DIFF
--- a/src/RetrySettings.php
+++ b/src/RetrySettings.php
@@ -383,9 +383,7 @@ class RetrySettings
      * Creates an associative array of the {@see Google\ApiCore\RetrySettings} timeout fields configured
      * with the given timeout specified in the $timeout parameter interpreted as a logical timeout.
      *
-     * @param int $timeout {
-     *     The timeout in milliseconds to be used as a logical call timeout.
-     * }
+     * @param int $timeout The timeout in milliseconds to be used as a logical call timeout.
      * @return array
      */
     public static function logicalTimeout($timeout)

--- a/src/RetrySettings.php
+++ b/src/RetrySettings.php
@@ -168,6 +168,36 @@ namespace Google\ApiCore;
  *     ],
  * ]);
  * ```
+ *
+ * Configure the use of logical timeout
+ * ------------------------------------
+ *
+ * To configure the use of a logical timeout, where a logical timeout is the
+ * duration a method is given to complete one or more RPC attempts, with each
+ * attempt using only the time remaining in the logical timeout, use
+ * {@see Google\ApiCore\RetrySettings::logicalTimeout()} combined with
+ * {@see Google\ApiCore\RetrySettings::with()}.
+ *
+ * ```
+ * $timeoutSettings = RetrySettings::logicalTimeout(30000);
+ *
+ * $customRetrySettings = $customRetrySettings->with($timeoutSettings);
+ *
+ * $result = $client->listGroups($name, [
+ *     'retrySettings' => $customRetrySettings
+ * ]);
+ * ```
+ *
+ * {@see Google\ApiCore\RetrySettings::logicalTimeout()} can also be used on a
+ * method call independent of a RetrySettings instance.
+ *
+ * ```
+ * $timeoutSettings = RetrySettings::logicalTimeout(30000);
+ *
+ * $result = $client->listGroups($name, [
+ *     'retrySettings' => $timeoutSettings
+ * ]);
+ * ```
  */
 class RetrySettings
 {
@@ -347,6 +377,26 @@ class RetrySettings
             'noRetriesRpcTimeoutMillis' => $this->getNoRetriesRpcTimeoutMillis(),
         ];
         return new RetrySettings($settings + $existingSettings);
+    }
+
+    /**
+     * Creates an associative array of the {@see Google\ApiCore\RetrySettings} timeout fields configured
+     * with the given timeout specified in the $timeout parameter interpreted as a logical timeout.
+     *
+     * @param int $timeout {
+     *     The timeout in milliseconds to be used as a logical call timeout.
+     * }
+     * @return array
+     */
+    public static function logicalTimeout($timeout)
+    {
+        return [
+            'initialRpcTimeoutMillis' => $timeout,
+            'maxRpcTimeoutMillis' => $timeout,
+            'totalTimeoutMillis' => $timeout,
+            'noRetriesRpcTimeoutMillis' => $timeout,
+            'rpcTimeoutMultiplier' => 1.0
+        ];
     }
 
     /**

--- a/tests/Tests/Unit/RetrySettingsTest.php
+++ b/tests/Tests/Unit/RetrySettingsTest.php
@@ -143,6 +143,23 @@ class RetrySettingsTest extends TestCase
         $this->compare($withRetrySettings, $expectedValues);
     }
 
+    public function testLogicalTimeout()
+    {
+        $timeout = 10000;
+        $expectedValues = [
+            'initialRpcTimeoutMillis' => $timeout,
+            'maxRpcTimeoutMillis' => $timeout,
+            'totalTimeoutMillis' => $timeout,
+            'noRetriesRpcTimeoutMillis' => $timeout,
+            'rpcTimeoutMultiplier' => 1.0
+        ];
+        $timeoutSettings = RetrySettings::logicalTimeout($timeout);
+        $this->assertSame(
+            $expectedValues,
+            $timeoutSettings
+        );
+    }
+
     private function compare(RetrySettings $retrySettings, $expectedValues)
     {
         $this->assertSame(


### PR DESCRIPTION
This PR adds a helper to the `RetrySettings` for configuring a logical call timeout. This helper, `logicalTimeout`, takes a single integer and applies it to each of the four existing timeout settings and sets the timeout multiplier to 1, returning an associative array for use with `with()` or via the `retrySettings` call option. The result is that each RPC attempt will take no longer than the time remaining in the overall deadline calculated at the start of the first call using the given timeout. The time remaining in this overall deadline is the timeout for each RPC attempt.

This helper is meant to simplify how users can think about the timeout settings, and reduce the need for `DEADLINE_EXCEEDED` to be retryable, which is an anti-pattern, but necessary for the "timeout backoff" strategy available via the existing retry/timeout logic.