### PR TITLE
[gax-php] feat: add REST headers

### DIFF
--- a/src/AgentHeader.php
+++ b/src/AgentHeader.php
@@ -50,7 +50,7 @@ class AgentHeader
      *     @type string $gapicVersion the code generator version of the GAPIC library.
      *     @type string $apiCoreVersion the ApiCore version.
      *     @type string $grpcVersion the gRPC version.
-     *     @type string $restVErsion the REST transport version (typically same as the
+     *     @type string $restVersion the REST transport version (typically same as the
      *           ApiCore version).
      * }
      * @return array Agent header array

--- a/src/AgentHeader.php
+++ b/src/AgentHeader.php
@@ -50,6 +50,8 @@ class AgentHeader
      *     @type string $gapicVersion the code generator version of the GAPIC library.
      *     @type string $apiCoreVersion the ApiCore version.
      *     @type string $grpcVersion the gRPC version.
+     *     @type string $restVErsion the REST transport version (typically same as the
+     *           ApiCore version).
      * }
      * @return array Agent header array
      */

--- a/src/AgentHeader.php
+++ b/src/AgentHeader.php
@@ -64,6 +64,7 @@ class AgentHeader
         //      - gapicVersion (gapic/)
         //      - apiCoreVersion (gax/)
         //      - grpcVersion (grpc/)
+        //      - restVersion (rest/)
 
         $phpVersion = isset($headerInfo['phpVersion'])
             ? $headerInfo['phpVersion']
@@ -87,10 +88,22 @@ class AgentHeader
             : Version::getApiCoreVersion();
         $metricsHeaders['gax'] = $apiCoreVersion;
 
+        // Context on library type identification (between gRPC+REST and REST-only):
+        // This uses the gRPC extension's version if 'grpcVersion' is not set, so we
+        // cannot use the presence of 'grpcVersion' to determine whether or not a library
+        // is gRPC+REST or REST-only. However, we cannot use the extension's presence
+        // either, since some clients may have the extension installed but opt to use a
+        // REST-only library (e.g. GCE).
+        // TODO: Should we stop sending empty gRPC headers?
         $grpcVersion = isset($headerInfo['grpcVersion'])
             ? $headerInfo['grpcVersion']
             : phpversion('grpc');
         $metricsHeaders['grpc'] = $grpcVersion;
+
+        $restVersion = isset($headerInfo['restVersion'])
+            ? $headerInfo['restVersion']
+            : $apiCoreVersion;
+        $metricsHeaders['rest'] = $restVersion;
 
         $metricsList = [];
         foreach ($metricsHeaders as $key => $value) {

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -323,12 +323,6 @@ trait GapicClientTrait
         // a REST-only library, then the grpcVersion header should not be set.
         // Note: The case where defaultTransport() returns 'rest' is implemented
         // in the microgenerator, not in gax-php.
-        // Historical context: AgentHeaders used to leverage the gRPC extension's version
-        // if 'grpcVersion' was not set, so we cannot use the presence of 'grpcVersion'
-        // to determine whether or not a library is gRPC+REST or REST-only. However,
-        // we cannot use the extension's presence either, since some clients may have
-        // the extension installed but opt to use a REST-only library (e.g. GCE).
-
         if ($this->defaultTransport() === 'rest') {
             // TODO: If/when we support gRPC-only libraries, do not unset the grpcVersion header.
             if (isset($options['grpcVersion'])) {

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -324,7 +324,7 @@ trait GapicClientTrait
         if ($this->transport instanceof GrpcTransport) {
             $options['grpcVersion'] = phpversion('grpc');
             unset($options['restVersion']);
-        } else if ($this->transport instanceof RestTransport 
+        } elseif ($this->transport instanceof RestTransport
             || $this->transport instanceof GrpcFallbackTransport) {
             unset($options['grpcVersion']);
             $options['restVersion'] = Version::getApiCoreVersion();

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -321,13 +321,11 @@ trait GapicClientTrait
 
         // Edge case: If the client has the gRPC extension installed, but is
         // a REST-only library, then the grpcVersion header should not be set.
-        if ($this->transport instanceof GrpcFallbackTransport) {
-            $options['grpcVersion'] = phpversion('grpc');
-            $options['restVersion'] = Version::getApiCoreVersion();
-        } else if ($this->transport instanceof GrpcTransport) {
+        if ($this->transport instanceof GrpcTransport) {
             $options['grpcVersion'] = phpversion('grpc');
             unset($options['restVersion']);
-        } else if ($this->transport instanceof RestTransport) {
+        } else if ($this->transport instanceof RestTransport 
+            || $this->transport instanceof GrpcFallbackTransport) {
             unset($options['grpcVersion']);
             $options['restVersion'] = Version::getApiCoreVersion();
         }

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -321,16 +321,15 @@ trait GapicClientTrait
 
         // Edge case: If the client has the gRPC extension installed, but is
         // a REST-only library, then the grpcVersion header should not be set.
-        // Note: The case where defaultTransport() returns 'rest' is implemented
-        // in the microgenerator, not in gax-php.
-        if ($this->defaultTransport() === 'rest') {
-            // TODO: If/when we support gRPC-only libraries, do not unset the grpcVersion header.
-            if (isset($options['grpcVersion'])) {
-                unset($options['grpcVersion']);
-            }
-            if (!isset($options['restVersion'])) {
-                $options['restVersion'] = Version::getApiCoreVersion();
-            }
+        if ($this->transport instanceof GrpcFallbackTransport) {
+            $options['grpcVersion'] = phpversion('grpc');
+            $options['restVersion'] = Version::getApiCoreVersion();
+        } else if ($this->transport instanceof GrpcTransport) {
+            $options['grpcVersion'] = phpversion('grpc');
+            unset($options['restVersion']);
+        } else if ($this->transport instanceof RestTransport) {
+            unset($options['grpcVersion']);
+            $options['restVersion'] = Version::getApiCoreVersion();
         }
 
         $this->agentHeader = AgentHeader::buildAgentHeader(

--- a/tests/Tests/Unit/AgentHeaderTest.php
+++ b/tests/Tests/Unit/AgentHeaderTest.php
@@ -43,7 +43,8 @@ class AgentHeaderTest extends TestCase
             'gl-php/' . phpversion() .
             ' gapic/' .
             ' gax/' . Version::getApiCoreVersion() .
-            ' grpc/' . phpversion('grpc')
+            ' grpc/' . phpversion('grpc') .
+            ' rest/' . Version::getApiCoreVersion()
         ]];
 
         $header = AgentHeader::buildAgentHeader([]);
@@ -53,7 +54,7 @@ class AgentHeaderTest extends TestCase
     public function testWithInput()
     {
         $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
-            'gl-php/4.4.4 gccl/1.1.1 gapic/2.2.2 gax/3.3.3 grpc/5.5.5'
+            'gl-php/4.4.4 gccl/1.1.1 gapic/2.2.2 gax/3.3.3 grpc/5.5.5 rest/3.3.3'
         ]];
 
         $header = AgentHeader::buildAgentHeader([
@@ -73,7 +74,8 @@ class AgentHeaderTest extends TestCase
         $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
             'gl-php/' . phpversion() .
             ' gccl/ gapic/ gax/' . Version::getApiCoreVersion() .
-            ' grpc/' . phpversion('grpc')
+            ' grpc/' . phpversion('grpc') .
+            ' rest/' . Version::getApiCoreVersion()
         ]];
 
         $header = AgentHeader::buildAgentHeader([
@@ -88,7 +90,8 @@ class AgentHeaderTest extends TestCase
         $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
             'gl-php/' . phpversion() .
             ' gccl/ gapic/ gax/' . Version::getApiCoreVersion() .
-            ' grpc/' . phpversion('grpc')
+            ' grpc/' . phpversion('grpc') .
+            ' rest/' . Version::getApiCoreVersion()
         ]];
 
         $header = AgentHeader::buildAgentHeader([
@@ -114,5 +117,34 @@ class AgentHeaderTest extends TestCase
     public function testGetGapicVersionWithNoAvailableVersion()
     {
         $this->assertEquals('', AgentHeader::readGapicVersionFromFile(__CLASS__));
+    }
+
+    public function testWithGrpcAndRest()
+    {
+        $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
+            'gl-php/7.4.15 gapic/ gax/3.3.3 grpc/4.4.4 rest/5.5.5'
+        ]];
+
+        $header = AgentHeader::buildAgentHeader([
+            'apiCoreVersion' => '3.3.3',
+            'grpcVersion' => '4.4.4',
+            'restVersion' => '5.5.5',
+        ]);
+
+        $this->assertSame($expectedHeader, $header);
+    }
+
+    public function testWithRestAndGaxFallback()
+    {
+        $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
+            'gl-php/7.4.15 gapic/ gax/3.3.3 grpc/ rest/3.3.3'
+        ]];
+
+        $header = AgentHeader::buildAgentHeader([
+            'apiCoreVersion' => '3.3.3',
+            'restVersion' => null,
+        ]);
+
+        $this->assertSame($expectedHeader, $header);
     }
 }

--- a/tests/Tests/Unit/AgentHeaderTest.php
+++ b/tests/Tests/Unit/AgentHeaderTest.php
@@ -122,7 +122,11 @@ class AgentHeaderTest extends TestCase
     public function testWithGrpcAndRest()
     {
         $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
-            'gl-php/7.4.15 gapic/ gax/3.3.3 grpc/4.4.4 rest/5.5.5'
+            'gl-php/' . phpversion() .
+            ' gapic/' .
+            ' gax/3.3.3' .
+            ' grpc/4.4.4' .
+            ' rest/5.5.5'
         ]];
 
         $header = AgentHeader::buildAgentHeader([
@@ -137,7 +141,11 @@ class AgentHeaderTest extends TestCase
     public function testWithRestAndGaxFallback()
     {
         $expectedHeader = [AgentHeader::AGENT_HEADER_KEY => [
-            'gl-php/7.4.15 gapic/ gax/3.3.3 grpc/ rest/3.3.3'
+            'gl-php/' . phpversion() .
+            ' gapic/' .
+            ' gax/3.3.3' .
+            ' grpc/' . phpversion('grpc') .
+            ' rest/3.3.3'
         ]];
 
         $header = AgentHeader::buildAgentHeader([

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -85,7 +85,7 @@ class GapicClientTraitTest extends TestCase
             'new-header' => ['this-should-be-used']
         ];
         $expectedHeaders = [
-            'x-goog-api-client' => ['gl-php/5.5.0 gccl/0.0.0 gapic/0.9.0 gax/1.0.0 grpc/1.0.1'],
+            'x-goog-api-client' => ['gl-php/5.5.0 gccl/0.0.0 gapic/0.9.0 gax/1.0.0 grpc/1.0.1 rest/1.0.0'],
             'new-header' => ['this-should-be-used'],
         ];
         $transport = $this->getMock(TransportInterface::class);


### PR DESCRIPTION
This is needed primarily for REGAPIC. However, sending the REST header can also benefit gRPC and REST GAPIC libraries (the default) as well, since we don't support gRPC-only libraries.

Using gax-php's version as the default REST version.