### PR TITLE
feat: allow ServiceAccountJwtAccessCredentials to sign scopes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.5",
-        "google/auth": "^1.16.0",
+        "google/auth": "^1.17.0",
         "google/grpc-gcp": "^0.1.0",
         "grpc/grpc": "^1.13",
         "google/protobuf": "^3.12.2",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.5",
-        "google/auth": "^1.2.0",
+        "google/auth": "^1.16.0",
         "google/grpc-gcp": "^0.1.0",
         "grpc/grpc": "^1.13",
         "google/protobuf": "^3.12.2",

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -35,6 +35,7 @@ use DomainException;
 use Exception;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Cache\MemoryCacheItemPool;
+use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\FetchAuthTokenInterface;
@@ -98,6 +99,9 @@ class CredentialsWrapper
      *     @type string[] $defaultScopes
      *           A string array of default scopes to use when acquiring
      *           credentials.
+     *     @type bool $useJwtAccessWithScope
+     *           Ensures service account credentials use JWT Access (also known as self-signed
+     *           JWTs), even when user-defined scopes are supplied.
      * }
      * @return CredentialsWrapper
      * @throws ValidationException
@@ -113,6 +117,7 @@ class CredentialsWrapper
             'authCacheOptions'  => [],
             'quotaProject'      => null,
             'defaultScopes'     => null,
+            'useJwtAccessWithScope' => false,
         ];
         $keyFile = $args['keyFile'];
         $authHttpHandler = $args['authHttpHandler'] ?: self::buildHttpHandlerFactory();
@@ -143,6 +148,12 @@ class CredentialsWrapper
                 $keyFile,
                 $args['defaultScopes']
             );
+        }
+
+        if ($loader instanceof ServiceAccountCredentials && $args['useJwtAccessWithScope']) {
+            // Ensures the ServiceAccountCredentials uses JWT Access, also known
+            // as self-signed JWTs, even when user-defined scopes are supplied.
+            $loader->useJwtAccessWithScope();
         }
 
         if ($args['enableCaching']) {

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -117,7 +117,7 @@ class CredentialsWrapper
             'authCacheOptions'  => [],
             'quotaProject'      => null,
             'defaultScopes'     => null,
-            'useJwtAccessWithScope' => false,
+            'useJwtAccessWithScope' => true,
         ];
         $keyFile = $args['keyFile'];
         $authHttpHandler = $args['authHttpHandler'] ?: self::buildHttpHandlerFactory();

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -162,12 +162,20 @@ trait GapicClientTrait
             'libName' => null,
             'libVersion' => null,
             'apiEndpoint' => null,
+            'useJwtAccessWithScope' => true,
         ];
-        $defaultOptions['transportConfig'] += [
-            'grpc' => ['stubOpts' => ['grpc.service_config_disable_resolution' => 1]],
-            'rest' => [],
-            'grpc-fallback' => [],
-        ];
+
+        $supportedTransports = $this->supportedTransports();
+        foreach ($supportedTransports as $transportName) {
+            if (!array_key_exists($transportName, $defaultOptions['transportConfig'])) {
+                $defaultOptions['transportConfig'][$transportName] = [];
+            }
+        }
+        if (in_array('grpc', $supportedTransports)) {
+            $defaultOptions['transportConfig']['grpc'] = [
+                'stubOpts' => ['grpc.service_config_disable_resolution' => 1]
+            ];
+        }
 
         // Merge defaults into $options starting from top level
         // variables, then going into deeper nesting, so that
@@ -175,10 +183,13 @@ trait GapicClientTrait
         $options += $defaultOptions;
         $options['credentialsConfig'] += $defaultOptions['credentialsConfig'];
         $options['transportConfig'] += $defaultOptions['transportConfig'];
-        $options['transportConfig']['grpc'] += $defaultOptions['transportConfig']['grpc'];
-        $options['transportConfig']['grpc']['stubOpts'] += $defaultOptions['transportConfig']['grpc']['stubOpts'];
-        $options['transportConfig']['rest'] += $defaultOptions['transportConfig']['rest'];
-        $options['transportConfig']['grpc-fallback'] += $defaultOptions['transportConfig']['grpc-fallback'];
+        if (isset($options['transportConfig']['grpc'])) {
+            $options['transportConfig']['grpc'] += $defaultOptions['transportConfig']['grpc'];
+            $options['transportConfig']['grpc']['stubOpts'] += $defaultOptions['transportConfig']['grpc']['stubOpts'];
+        }
+        if (isset($options['transportConfig']['rest'])) {
+            $options['transportConfig']['rest'] += $defaultOptions['transportConfig']['rest'];
+        }
 
         $this->modifyClientOptions($options);
 

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -162,7 +162,6 @@ trait GapicClientTrait
             'libName' => null,
             'libVersion' => null,
             'apiEndpoint' => null,
-            'useJwtAccessWithScope' => true,
         ];
 
         $supportedTransports = $this->supportedTransports();

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -465,6 +465,7 @@ class GapicClientTraitTest extends TestCase
             'gapicVersion' => null,
             'libName' => null,
             'libVersion' => null,
+            'useJwtAccessWithScope' => true,
         ];
 
         $restConfigOptions = $defaultOptions;
@@ -494,6 +495,74 @@ class GapicClientTraitTest extends TestCase
                         ]
                     ]
                 ], $grpcConfigOptions
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider buildClientOptionsProviderRestOnly
+     */
+    public function testBuildClientOptionsRestOnly($options, $expectedUpdatedOptions)
+    {
+        if (!extension_loaded('sysvshm')) {
+            $this->markTestSkipped('The sysvshm extension must be installed to execute this test.');
+        }
+        $client = new GapicClientTraitRestOnly();
+        $updatedOptions = $client->call('buildClientOptions', [$options]);
+        $this->assertEquals($expectedUpdatedOptions, $updatedOptions);
+    }
+
+    public function buildClientOptionsProviderRestOnly()
+    {
+        $defaultOptions = [
+            'apiEndpoint' => 'test.address.com:443',
+            'serviceName' => 'test.interface.v1.api',
+            'clientConfig' => __DIR__ . '/testdata/test_service_client_config.json',
+            'descriptorsConfigPath' => __DIR__.'/testdata/test_service_descriptor_config.php',
+            'disableRetries' => false,
+            'transport' => null,
+            'transportConfig' => [
+                'rest' => [
+                    'restClientConfigPath' => __DIR__.'/testdata/test_service_rest_client_config.php',
+                ],
+                'fake-transport' => []
+            ],
+            'credentials' => null,
+            'credentialsConfig' => [],
+            'gapicVersion' => null,
+            'libName' => null,
+            'libVersion' => null,
+            'useJwtAccessWithScope' => false,
+        ];
+
+        $restConfigOptions = $defaultOptions;
+        $restConfigOptions['transportConfig']['rest'] += [
+            'customRestConfig' => 'value'
+        ];
+
+        $fakeTransportConfigOptions = $defaultOptions;
+        $fakeTransportConfigOptions['transportConfig']['fake-transport'] += [
+            'customRestConfig' => 'value'
+        ];
+        return [
+            [[], $defaultOptions],
+            [
+                [
+                    'transportConfig' => [
+                        'rest' => [
+                            'customRestConfig' => 'value'
+                        ]
+                    ]
+                ], $restConfigOptions
+            ],
+            [
+                [
+                    'transportConfig' => [
+                        'fake-transport' => [
+                            'customRestConfig' => 'value'
+                        ]
+                    ]
+                ], $fakeTransportConfigOptions
             ],
         ];
     }
@@ -1107,7 +1176,13 @@ class GapicClientTraitRestOnly
                     'restClientConfigPath' => __DIR__.'/testdata/test_service_rest_client_config.php',
                 ]
             ],
+            'useJwtAccessWithScope' => false,
         ];
+    }
+
+    public function call($fn, array $args = [])
+    {
+        return call_user_func_array([$this, $fn], $args);
     }
 
     public function getTransport()

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -465,7 +465,6 @@ class GapicClientTraitTest extends TestCase
             'gapicVersion' => null,
             'libName' => null,
             'libVersion' => null,
-            'useJwtAccessWithScope' => true,
         ];
 
         $restConfigOptions = $defaultOptions;
@@ -532,7 +531,6 @@ class GapicClientTraitTest extends TestCase
             'gapicVersion' => null,
             'libName' => null,
             'libVersion' => null,
-            'useJwtAccessWithScope' => false,
         ];
 
         $restConfigOptions = $defaultOptions;
@@ -1176,7 +1174,6 @@ class GapicClientTraitRestOnly
                     'restClientConfigPath' => __DIR__.'/testdata/test_service_rest_client_config.php',
                 ]
             ],
-            'useJwtAccessWithScope' => false,
         ];
     }
 


### PR DESCRIPTION
**TODO** 
- [x] Merge and tag https://github.com/googleapis/google-auth-library-php/pull/341
- [x] Update minimum `google/auth` version in `composer.json` to the new tag ([v1.16.0](https://github.com/googleapis/google-auth-library-php/releases/tag/v1.16.0))
- [x] Add `'useJwtAccessWithScopes' => false` to `gapic-generator-php` for DIREGAPIC APIs (done in https://github.com/googleapis/gapic-generator-php/pull/309)
- [x] Generate a new [Gapic Compute client](https://github.com/googleapis/google-cloud-php/tree/master/Compute) with the changes in https://github.com/googleapis/gapic-generator-php/pull/309

_Note_: These steps are now optional because Compute does not need the exclusion for Self-Signed JWTs with Scopes

- [ ] Merge https://github.com/googleapis/google-cloud-php/pull/4199
- [ ] Tag a new version of `google/cloud-compute`
- [ ] Merge _this PR_
- [ ] Tag a new version of _this library_ (`google/gax`)
- [ ] Update [Gapic Compute client](https://github.com/googleapis/google-cloud-php/tree/master/Compute) requires [the latest tag of google/gax](https://github.com/googleapis/google-cloud-php/blob/master/Compute/composer.json#L8)