### PR TITLE
fix: ensure required query parameters with default values get sent over the wire

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -177,6 +177,18 @@ class RequestBuilder
             }
         }
 
+        // Ensures required query params with default values are always sent
+        // over the wire.
+        if (isset($config['queryParams'])) {
+            foreach ($config['queryParams'] as $requiredQueryParam) {
+                $requiredQueryParam = Serializer::toCamelCase($requiredQueryParam);
+                if (!array_key_exists($requiredQueryParam, $queryParams)) {
+                    $getter = Serializer::getGetter($requiredQueryParam);
+                    $queryParams[$requiredQueryParam] = $message->$getter();
+                }
+            }
+        }
+
         return [$body, $queryParams];
     }
 

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -337,6 +337,19 @@ class RequestBuilderTest extends TestCase
         $this->assertEquals('some-value', $query['stringValue']);
     }
 
+    public function testMethodWithRequiredQueryParametersAndDefaultValues()
+    {
+        $message = (new MockRequestBody())
+            ->setName('')
+            ->setNumber(0);
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithRequiredQueryParameters', $message);
+        $query = Psr7\parse_query($request->getUri()->getQuery());
+
+        $this->assertEquals('', $query['name']);
+        $this->assertEquals(0, $query['number']);
+    }
+
     public function testMethodWithComplexMessageInQueryString()
     {
         $message = (new MockRequestBody())

--- a/tests/Tests/Unit/testdata/test_service_rest_client_config.php
+++ b/tests/Tests/Unit/testdata/test_service_rest_client_config.php
@@ -137,6 +137,14 @@ return [
                 'method' => 'get',
                 'uriTemplate' => '/v1/fixedurl',
             ],
+            'MethodWithRequiredQueryParameters' => [
+                'method' => 'get',
+                'uriTemplate' => '/v1/fixedurl',
+                'queryParams' => [
+                    'name',
+                    'number'
+                ]
+            ]
         ],
     ],
 ];


### PR DESCRIPTION
Follows https://github.com/googleapis/gapic-generator-php/commit/2d5ef5853544d58de2b6fdd5cb8335c38174af23