### PR TITLE
fix: urlencode request params only

### DIFF
--- a/src/RequestParamsHeaderDescriptor.php
+++ b/src/RequestParamsHeaderDescriptor.php
@@ -59,13 +59,8 @@ class RequestParamsHeaderDescriptor
             if ('' !== $headerValue) {
                 $headerValue .= '&';
             }
-            $headerValue .= $key . '=' . strval($value);
-        }
 
-        // If the value contains non-ASCII characters, suffix the header key with `-bin`.
-        // see https://grpc.github.io/grpc/python/glossary.html#term-metadata
-        if (preg_match('/[^\x00-\x7F]/', $headerValue) !== 0) {
-            $headerKey = $headerKey . '-bin';
+            $headerValue .= $key . '=' . urlencode(strval($value));
         }
 
         $this->header = [$headerKey => [$headerValue]];

--- a/tests/Tests/Unit/RequestParamsHeaderDescriptorTest.php
+++ b/tests/Tests/Unit/RequestParamsHeaderDescriptorTest.php
@@ -72,11 +72,11 @@ class RequestParamsHeaderDescriptorTest extends TestCase
         $this->assertSame($expectedHeader, $header);
     }
 
-    public function testNonAsciiCharsAppendsBinToHeaderKey()
+    public function testNonAsciiChars()
     {
         $val = 'こんにちは';
         $expectedHeader = [
-            RequestParamsHeaderDescriptor::HEADER_KEY . '-bin' => ['field1=' . $val]
+            RequestParamsHeaderDescriptor::HEADER_KEY => ['field1=' . urlencode($val)]
         ];
 
         $agentHeaderDescriptor = new RequestParamsHeaderDescriptor(['field1' => $val]);


### PR DESCRIPTION
see https://github.com/googleapis/gax-php/pull/255

Instead of using `x-goog-request-params-bin` for non-ASCII Unicode characters, we can use `urlencode`. I believe the latter is what the API will expect, and I'm not sure `x-goog-request-params-bin` is supported.

The [Routing Headers documentation](https://google.aip.dev/client-libraries/4222) state these values should be URL-encoded.
So this PR does two things:

1. Adds URL-encoding for all `x-goog-request-params` values
2. Removes use of `x-goog-request-params-bin`.

The second of these is a little concerning, as the gRPC docs state [headers with non-ASCII should use `-bin`](https://grpc.github.io/grpc/python/glossary.html#term-metadata). We could add a check for non-ASCII and preserve the existing behavior, if this is a big enough concern.