### PR TITLE
chore: Lint the code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
                 timeout_minutes: 10
                 max_attempts: 3
                 command: composer install
+            - name: Lint code
+              run: vendor/bin/parallel-lint --exclude dev --exclude vendor .
             - name: Run script
               env:
                 GOOGLE_APPLICATION_CREDENTIALS: ${{github.workspace}}/tests/Tests/Unit/testdata/json-key-file.json

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
         "google/common-protos": "^1.0"
     },
     "require-dev": {
+        "php-parallel-lint/php-console-highlighter": "^0.5.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpunit/phpunit": "^4.8.36",
         "squizlabs/php_codesniffer": "3.*"
     },


### PR DESCRIPTION
When a package is supported by a very wide range of PHP versions, it is very easy to introduce some syntax errors.

Those errors should ideally be found before the testing phase, eg. in the linting phase

This PR adds 2 packages to lint the code and update the main testing workflows to introduce enforce this linting.
One linting analysis will be run for each PHP version