### PR TITLE
chore: tests assertions

### DIFF
--- a/src/Testing/GeneratedTest.php
+++ b/src/Testing/GeneratedTest.php
@@ -50,7 +50,7 @@ abstract class GeneratedTest extends TestCase
                 $this->assertEquals($expected, $actual);
             }
 
-            $this->assertSame(count($expected), count($actual));
+            $this->assertCount(count($expected), $actual);
 
             $expectedValues = $this->getValues($expected);
             $actualValues = $this->getValues($actual);

--- a/tests/Tests/Unit/AgentHeaderTest.php
+++ b/tests/Tests/Unit/AgentHeaderTest.php
@@ -116,7 +116,7 @@ class AgentHeaderTest extends TestCase
 
     public function testGetGapicVersionWithNoAvailableVersion()
     {
-        $this->assertEquals('', AgentHeader::readGapicVersionFromFile(__CLASS__));
+        $this->assertSame('', AgentHeader::readGapicVersionFromFile(__CLASS__));
     }
 
     public function testWithGrpcAndRest()

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -639,7 +639,7 @@ class GapicClientTraitTest extends TestCase
         $updatedOptions = $client->call('buildClientOptions', [$options]);
 
         $this->assertArrayHasKey('addNewOption', $updatedOptions);
-        $this->assertSame(true, $updatedOptions['disableRetries']);
+        $this->assertTrue($updatedOptions['disableRetries']);
     }
 
     private function buildClientToTestModifyCallMethods()

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -212,7 +212,7 @@ class GapicClientTraitTest extends TestCase
     public function testGetGapicVersionWithNoAvailableVersion()
     {
         $client = new GapicClientTraitStub();
-        $this->assertEquals('', $client->call('getGapicVersion', [[]]));
+        $this->assertSame('', $client->call('getGapicVersion', [[]]));
     }
 
     public function testGetGapicVersionWithLibVersion()
@@ -1229,7 +1229,7 @@ class GapicClientTraitTest extends TestCase
         $client = new GapicClientTraitStub();
         $options = $client->call('buildClientOptions', [[]]);
 
-        $this->assertEquals('test.mtls.address.com:443', $options['apiEndpoint']);
+        $this->assertSame('test.mtls.address.com:443', $options['apiEndpoint']);
         $this->assertTrue(is_callable($options['clientCertSource']));
         $this->assertEquals(['foo', 'foo'], $options['clientCertSource']());
     }

--- a/tests/Tests/Unit/LongRunning/OperationsClientTest.php
+++ b/tests/Tests/Unit/LongRunning/OperationsClientTest.php
@@ -96,7 +96,7 @@ class OperationsClientTest extends GeneratedTest
         $response = $client->getOperation($name);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
-        $this->assertSame(1, count($actualRequests));
+        $this->assertCount(1, $actualRequests);
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
         $this->assertSame('/google.longrunning.Operations/GetOperation', $actualFuncCall);
@@ -173,11 +173,11 @@ class OperationsClientTest extends GeneratedTest
         $response = $client->listOperations($name, $filter);
         $this->assertEquals($expectedResponse, $response->getPage()->getResponseObject());
         $resources = iterator_to_array($response->iterateAllElements());
-        $this->assertSame(1, count($resources));
+        $this->assertCount(1, $resources);
         $this->assertEquals($expectedResponse->getOperations()[0], $resources[0]);
 
         $actualRequests = $transport->popReceivedCalls();
-        $this->assertSame(1, count($actualRequests));
+        $this->assertCount(1, $actualRequests);
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
         $this->assertSame('/google.longrunning.Operations/ListOperations', $actualFuncCall);
@@ -250,7 +250,7 @@ class OperationsClientTest extends GeneratedTest
 
         $client->cancelOperation($name);
         $actualRequests = $transport->popReceivedCalls();
-        $this->assertSame(1, count($actualRequests));
+        $this->assertCount(1, $actualRequests);
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
         $this->assertSame('/google.longrunning.Operations/CancelOperation', $actualFuncCall);
@@ -320,7 +320,7 @@ class OperationsClientTest extends GeneratedTest
 
         $client->deleteOperation($name);
         $actualRequests = $transport->popReceivedCalls();
-        $this->assertSame(1, count($actualRequests));
+        $this->assertCount(1, $actualRequests);
         $actualFuncCall = $actualRequests[0]->getFuncCall();
         $actualRequestObject = $actualRequests[0]->getRequestObject();
         $this->assertSame('/google.longrunning.Operations/DeleteOperation', $actualFuncCall);

--- a/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -94,7 +94,7 @@ class RetryMiddlewareTest extends TestCase
             []
         )->wait();
 
-        $this->assertEquals('Ok!', $response);
+        $this->assertSame('Ok!', $response);
         $this->assertEquals(3, $callCount);
     }
 
@@ -203,7 +203,7 @@ class RetryMiddlewareTest extends TestCase
             []
         )->wait();
 
-        $this->assertEquals('Ok!', $response);
+        $this->assertSame('Ok!', $response);
         $this->assertEquals(3, $callCount);
         $this->assertEquals(3, count($observedTimeouts));
         $this->assertEquals($observedTimeouts[0], $timeout);
@@ -231,7 +231,7 @@ class RetryMiddlewareTest extends TestCase
             []
         )->wait();
 
-        $this->assertEquals('Ok!', $response);
+        $this->assertSame('Ok!', $response);
         $this->assertEquals($observedTimeout, $timeout);
     }
 }

--- a/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -205,7 +205,7 @@ class RetryMiddlewareTest extends TestCase
 
         $this->assertSame('Ok!', $response);
         $this->assertEquals(3, $callCount);
-        $this->assertEquals(3, count($observedTimeouts));
+        $this->assertCount(3, $observedTimeouts);
         $this->assertEquals($observedTimeouts[0], $timeout);
         for ($i = 1; $i < count($observedTimeouts); $i++) {
             $this->assertTrue($observedTimeouts[$i-1] > $observedTimeouts[$i]);

--- a/tests/Tests/Unit/OperationResponseTest.php
+++ b/tests/Tests/Unit/OperationResponseTest.php
@@ -265,7 +265,7 @@ class OperationResponseTest extends TestCase
 
         $this->assertNotNull($error);
         $this->assertEquals(Code::INTERNAL, $error->getCode());
-        $this->assertEquals('It failed, sorry :(', $error->getMessage());
+        $this->assertSame('It failed, sorry :(', $error->getMessage());
     }
 
     public function testEmptyCustomOperationErrorIsSuccessful()

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -57,7 +57,7 @@ class RequestBuilderTest extends TestCase
 
         $this->assertEmpty($uri->getQuery());
         $this->assertEmpty((string) $request->getBody());
-        $this->assertEquals('/v1/message/foo', $uri->getPath());
+        $this->assertSame('/v1/message/foo', $uri->getPath());
     }
 
     public function testMethodWithBody()
@@ -72,7 +72,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty($uri->getQuery());
-        $this->assertEquals('/v1/message/foo', $uri->getPath());
+        $this->assertSame('/v1/message/foo', $uri->getPath());
         $this->assertEquals(
             ['name' => 'message/foo', 'nestedMessage' => ['name' => 'nested/foo']],
             json_decode($request->getBody(), true)
@@ -91,7 +91,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty($uri->getQuery());
-        $this->assertEquals('/v1/message/foo', $uri->getPath());
+        $this->assertSame('/v1/message/foo', $uri->getPath());
         $this->assertEquals(
             ['name' => 'nested/foo'],
             json_decode($request->getBody(), true)
@@ -155,7 +155,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty($uri->getQuery());
-        $this->assertEquals('/v1/nested/foo', $uri->getPath());
+        $this->assertSame('/v1/nested/foo', $uri->getPath());
         $this->assertEquals(
             ['name' => 'message/foo', 'nestedMessage' => ['name' => 'nested/foo']],
             json_decode($request->getBody(), true)
@@ -172,8 +172,8 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty((string) $request->getBody());
-        $this->assertEquals('/v1/message/foo', $uri->getPath());
-        $this->assertEquals('repeatedField=bar1&repeatedField=bar2', $uri->getQuery());
+        $this->assertSame('/v1/message/foo', $uri->getPath());
+        $this->assertSame('repeatedField=bar1&repeatedField=bar2', $uri->getQuery());
     }
 
     public function testMethodWithHeaders()
@@ -186,9 +186,9 @@ class RequestBuilderTest extends TestCase
             'header2' => 'value2'
         ]);
 
-        $this->assertEquals('value1', $request->getHeaderLine('header1'));
-        $this->assertEquals('value2', $request->getHeaderLine('header2'));
-        $this->assertEquals('application/json', $request->getHeaderLine('Content-Type'));
+        $this->assertSame('value1', $request->getHeaderLine('header1'));
+        $this->assertSame('value2', $request->getHeaderLine('header2'));
+        $this->assertSame('application/json', $request->getHeaderLine('Content-Type'));
     }
 
     public function testMethodWithColon()
@@ -200,7 +200,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty($uri->getQuery());
-        $this->assertEquals('/v1/message/foo:action', $uri->getPath());
+        $this->assertSame('/v1/message/foo:action', $uri->getPath());
     }
 
     public function testMethodWithMultipleWildcardsAndColonInUrl()
@@ -216,7 +216,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty($uri->getQuery());
-        $this->assertEquals('/v1/message/foo/number/10:action', $uri->getPath());
+        $this->assertSame('/v1/message/foo/number/10:action', $uri->getPath());
     }
 
     public function testMethodWithSimplePlaceholder()
@@ -230,7 +230,7 @@ class RequestBuilderTest extends TestCase
         );
         $uri = $request->getUri();
 
-        $this->assertEquals('/v1/message-name', $uri->getPath());
+        $this->assertSame('/v1/message-name', $uri->getPath());
     }
 
     public function testMethodWithAdditionalBindings()
@@ -239,19 +239,19 @@ class RequestBuilderTest extends TestCase
         $message->setName('message/foo');
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithAdditionalBindings', $message);
 
-        $this->assertEquals('/v1/message/foo/additional/bindings', $request->getUri()->getPath());
+        $this->assertSame('/v1/message/foo/additional/bindings', $request->getUri()->getPath());
 
         $message->setName('different/format/foo');
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithAdditionalBindings', $message);
 
-        $this->assertEquals('/v1/different/format/foo/additional/bindings', $request->getUri()->getPath());
+        $this->assertSame('/v1/different/format/foo/additional/bindings', $request->getUri()->getPath());
 
         $nestedMessage = new MockRequestBody();
         $nestedMessage->setName('nested/foo');
         $message->setNestedMessage($nestedMessage);
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithAdditionalBindings', $message);
 
-        $this->assertEquals('/v2/nested/foo/additional/bindings', $request->getUri()->getPath());
+        $this->assertSame('/v2/nested/foo/additional/bindings', $request->getUri()->getPath());
     }
 
     public function testMethodWithSpecialJsonMapping()
@@ -301,22 +301,22 @@ class RequestBuilderTest extends TestCase
         $query = Query::parse($uri->getQuery());
 
 
-        $this->assertEquals('XDAwMA==', $query['bytesValue']);
+        $this->assertSame('XDAwMA==', $query['bytesValue']);
         // @todo (dwsupplee) Investigate differences in native protobuf implementation
         // between v3.7.0 and v3.9.0 - this passed previously with the value
         // "9001.000500000s".
         if (extension_loaded('protobuf')) {
-            $this->assertEquals('9001.000500000s', $query['durationValue']);
+            $this->assertSame('9001.000500000s', $query['durationValue']);
         } else {
-            $this->assertEquals('9001.000500s', $query['durationValue']);
+            $this->assertSame('9001.000500s', $query['durationValue']);
         }
-        $this->assertEquals('path1,path2', $query['fieldMask']);
+        $this->assertSame('path1,path2', $query['fieldMask']);
         $this->assertEquals(100, $query['int64Value']);
         $this->assertEquals(['val1', 'val2'], $query['listValue']);
-        $this->assertEquals('some-value', $query['stringValue']);
-        $this->assertEquals('val5', $query['structValue.test']);
-        $this->assertEquals('1970-01-01T02:30:01Z', $query['timestampValue']);
-        $this->assertEquals('some-value', $query['valueValue']);
+        $this->assertSame('some-value', $query['stringValue']);
+        $this->assertSame('val5', $query['structValue.test']);
+        $this->assertSame('1970-01-01T02:30:01Z', $query['timestampValue']);
+        $this->assertSame('some-value', $query['valueValue']);
     }
 
     public function testMethodWithoutPlaceholders()
@@ -334,8 +334,8 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithoutPlaceholders', $message);
         $query = Query::parse($request->getUri()->getQuery());
 
-        $this->assertEquals('path1,path2', $query['fieldMask']);
-        $this->assertEquals('some-value', $query['stringValue']);
+        $this->assertSame('path1,path2', $query['fieldMask']);
+        $this->assertSame('some-value', $query['stringValue']);
     }
 
     public function testMethodWithRequiredQueryParametersAndDefaultValues()
@@ -347,7 +347,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithRequiredQueryParameters', $message);
         $query = Query::parse($request->getUri()->getQuery());
 
-        $this->assertEquals('', $query['name']);
+        $this->assertSame('', $query['name']);
         $this->assertEquals(0, $query['number']);
     }
 
@@ -363,7 +363,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithoutPlaceholders', $message);
         $query = Query::parse($request->getUri()->getQuery());
 
-        $this->assertEquals('some-name', $query['nestedMessage.name']);
+        $this->assertSame('some-name', $query['nestedMessage.name']);
         $this->assertEquals(10, $query['nestedMessage.number']);
     }
 
@@ -375,7 +375,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithoutPlaceholders', $message);
         $query = Query::parse($request->getUri()->getQuery());
 
-        $this->assertEquals('some-value', $query['field1']);
+        $this->assertSame('some-value', $query['field1']);
     }
 
     /**

--- a/tests/Tests/Unit/Transport/Rest/JsonStreamDecoderTest.php
+++ b/tests/Tests/Unit/Transport/Rest/JsonStreamDecoderTest.php
@@ -137,7 +137,7 @@ class JsonStreamDecoderTest extends TestCase
         $stream->write($payload);
         $decoder = new JsonStreamDecoder($stream, Operation::class, ['readChunkSizeBytes' => 10]);
         foreach($decoder->decode() as $op) {
-            $this->assertEquals('foo', $op->getName());
+            $this->assertSame('foo', $op->getName());
             $stream->close();
         }
     }


### PR DESCRIPTION
This PR ensure that :
- stricter assertions are used for string comparisons (`assertEquals` -> `assertSame`)
- `assertCount` and `assertTrue` dedicated assertions are used when they should