### PR TITLE
chore: allow for google/common-protos 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         "grpc/grpc": "^1.13",
         "google/protobuf": "^3.12.2",
         "guzzlehttp/promises": "^1.3",
-        "guzzlehttp/psr7": "^1.7.0|^2",
-        "google/common-protos": "^1.0|^2.0"
+        "guzzlehttp/psr7": "^1.7.0||^2",
+        "google/common-protos": "^1.0||^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "google/protobuf": "^3.12.2",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.7.0|^2",
-        "google/common-protos": "^1.0"
+        "google/common-protos": "^1.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36",


### PR DESCRIPTION
Update to allow for `google/common-protos 2.0`. We are keeping `google/common-protos 1.0` for backwards-compatibility purposes. 