### PR TITLE
fix: support stdClass in MockServerStreamingCall

### DIFF
--- a/src/Testing/MockServerStreamingCall.php
+++ b/src/Testing/MockServerStreamingCall.php
@@ -36,6 +36,7 @@ use Google\ApiCore\ApiException;
 use Google\ApiCore\ApiStatus;
 use Google\Rpc\Code;
 use Google\Rpc\Status;
+use stdClass;
 
 /**
  * The MockServerStreamingCall class is used to mock out the \Grpc\ServerStreamingCall class
@@ -52,7 +53,7 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
      * MockServerStreamingCall constructor.
      * @param mixed[] $responses A list of response objects.
      * @param callable|null $deserialize An optional deserialize method for the response object.
-     * @param MockStatus|null $status An optional status object. If set to null, a status of OK is used.
+     * @param MockStatus|stdClass|null $status An optional status object. If set to null, a status of OK is used.
      */
     public function __construct($responses, $deserialize = null, $status = null)
     {
@@ -60,6 +61,10 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
         $this->deserialize = $deserialize;
         if (is_null($status)) {
             $status = new MockStatus(Code::OK, 'OK', []);
+        } elseif ($status instanceof stdClass) {
+            if (!property_exists($this->status, 'metadata')) {
+                $this->status->metadata = null;
+            }
         }
         $this->status = $status;
     }

--- a/src/Testing/MockServerStreamingCall.php
+++ b/src/Testing/MockServerStreamingCall.php
@@ -63,7 +63,7 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
             $status = new MockStatus(Code::OK, 'OK', []);
         } elseif ($status instanceof stdClass) {
             if (!property_exists($status, 'metadata')) {
-                $status->metadata = null;
+                $status->metadata = [];
             }
         }
         $this->status = $status;

--- a/src/Testing/MockServerStreamingCall.php
+++ b/src/Testing/MockServerStreamingCall.php
@@ -62,8 +62,8 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
         if (is_null($status)) {
             $status = new MockStatus(Code::OK, 'OK', []);
         } elseif ($status instanceof stdClass) {
-            if (!property_exists($this->status, 'metadata')) {
-                $this->status->metadata = null;
+            if (!property_exists($status, 'metadata')) {
+                $status->metadata = null;
             }
         }
         $this->status = $status;


### PR DESCRIPTION
Tests in `google/cloud` are failing with the following error:

```
1) Google\Cloud\BigQuery\Storage\Tests\Unit\V1\BigQueryReadClientTest::readRowsExceptionTest
Undefined property: stdClass::$metadata

/tmpfs/src/github/google-cloud-php/vendor/google/gax/src/Testing/MockServerStreamingCall.php:93
/tmpfs/src/github/google-cloud-php/vendor/google/gax/src/ServerStream.php:79
/tmpfs/src/github/google-cloud-php/BigQueryStorage/tests/Unit/V1/BigQueryReadClientTest.php:211
```

This should fix it!