### PR TITLE
fix: revert getStatus to stdClass in ServerStreamingCallInterface

### DIFF
--- a/src/ServerStream.php
+++ b/src/ServerStream.php
@@ -76,9 +76,12 @@ class ServerStream
                 yield $response;
             }
         }
+
+        // Errors in the REST transport will be thrown from there and not reach
+        // this handling. Successful REST server-streams will have an OK status.
         $status = $this->call->getStatus();
-        if ($status->getCode() !== Code::OK) {
-            throw ApiException::createFromRpcStatus($status);
+        if ($status->code !== Code::OK) {
+            throw ApiException::createFromStdClass($status);
         }
     }
 

--- a/src/ServerStreamingCallInterface.php
+++ b/src/ServerStreamingCallInterface.php
@@ -54,7 +54,7 @@ interface ServerStreamingCallInterface
     /**
      * Return the status of the server stream.
      *
-     * @return \Google\Rpc\Status The API status.
+     * @return \stdClass The API status.
      */
     public function getStatus();
 

--- a/src/Testing/MockServerStreamingCall.php
+++ b/src/Testing/MockServerStreamingCall.php
@@ -35,7 +35,6 @@ namespace Google\ApiCore\Testing;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\ApiStatus;
 use Google\Rpc\Code;
-use Google\Rpc\Status;
 use stdClass;
 
 /**
@@ -79,7 +78,7 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
     }
 
     /**
-     * @return \Google\Rpc\Status
+     * @return MockStatus|null|\stdClass
      * @throws ApiException
      */
     public function getStatus()
@@ -91,12 +90,6 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall
                 ApiStatus::INTERNAL
             );
         }
-        return new Status(
-            [
-                'code' => $this->status->code,
-                'message' => $this->status->details,
-                'details' => $this->status->metadata
-            ]
-        );
+        return $this->status;
     }
 }

--- a/src/Transport/Grpc/ServerStreamingCallWrapper.php
+++ b/src/Transport/Grpc/ServerStreamingCallWrapper.php
@@ -78,20 +78,7 @@ class ServerStreamingCallWrapper implements ServerStreamingCallInterface
      */
     public function getStatus()
     {
-        // Convert the \stdClass from the Grpc\ServerStreamingCall into a \Google\Rpc\Status.
-        $st = $this->stream->getStatus();
-        $code = property_exists($st, 'code') ? $st->code : Code::OK;
-        return new Status(
-            [
-                'code' => $code,
-                // Field 'details' is actually a string in this \stdClass.
-                'message' => property_exists($st, 'details') ? $st->details : '',
-                // Field 'metadata' is actually an array of objects in this \stdClass.
-                'details' => property_exists($st, 'metadata') && $code !== Code::OK
-                    ? Serializer::decodeMetadata($st->metadata)
-                    : []
-            ]
-        );
+        return $this->stream->getStatus();
     }
 
     /**

--- a/src/Transport/Rest/RestServerStreamingCall.php
+++ b/src/Transport/Rest/RestServerStreamingCall.php
@@ -36,8 +36,8 @@ use Google\ApiCore\ApiException;
 use Google\ApiCore\ApiStatus;
 use Google\ApiCore\ServerStreamingCallInterface;
 use Google\Rpc\Code;
-use Google\Rpc\Status;
 use GuzzleHttp\Exception\RequestException;
+use stdClass;
 
 /**
  * Class RestServerStreamingCall implements \Google\ApiCore\ServerStreamingCallInterface.
@@ -83,13 +83,11 @@ class RestServerStreamingCall implements ServerStreamingCallInterface
 
         // Create an OK Status for a successful request just so that it
         // has a return value.
-        $this->status = new Status(
-            [
-                'code' => Code::OK,
-                'message' => ApiStatus::OK,
-                'details' => []
-            ]
-        );
+        $this->status = new stdClass();
+        $this->status->code = Code::OK;
+        $this->status->message = ApiStatus::OK;
+        $this->status->details = [];
+
         $this->response = $response;
     }
 
@@ -129,7 +127,7 @@ class RestServerStreamingCall implements ServerStreamingCallInterface
      * Return the status of the server stream. If the call has not been started
      * this will be null.
      *
-     * @return \Google\Rpc\Status The status, with integer $code, string
+     * @return \stdClass The status, with integer $code, string
      *                   $details, and array $metadata members
      */
     public function getStatus()


### PR DESCRIPTION
This reverts the changes to the `getStatus` API of the server streaming calls that made it return `google.rpc.Status` rather than `stdClass`.  The REST flavor of ServerStream will throw an exception prior to `getStatus` calls, so that API is essentially not used in REST, so we shouldn't have changed the return type to something transport agnostic. This was also an accidental breaking change, even though the changes were to an internal interface/call stack.

Fixes #363, tested with the repro mentioned there.