### PR TITLE
feat: add rest interceptor support

### DIFF
--- a/src/Transport/HttpUnaryTransportTrait.php
+++ b/src/Transport/HttpUnaryTransportTrait.php
@@ -32,6 +32,7 @@
 namespace Google\ApiCore\Transport;
 
 use Exception;
+use GuzzleHttp\Client;
 use Google\ApiCore\Call;
 use Google\ApiCore\ValidationException;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
@@ -121,13 +122,14 @@ trait HttpUnaryTransportTrait
     }
 
     /**
-     * @return callable
+    * @param Client|null $client
+    * @return callable
      * @throws ValidationException
      */
-    private static function buildHttpHandlerAsync()
+    private static function buildHttpHandlerAsync(?Client $client = null)
     {
         try {
-            return [HttpHandlerFactory::build(), 'async'];
+            return [HttpHandlerFactory::build($client), 'async'];
         } catch (Exception $ex) {
             throw new ValidationException("Failed to build HttpHandler", $ex->getCode(), $ex);
         }

--- a/src/Transport/Rest/RestInterceptor.php
+++ b/src/Transport/Rest/RestInterceptor.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright 2022 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Google\ApiCore\Transport\Rest;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Middleware which adds an interceptor that intercepts RPC invocations before the call starts for REST-based requests.
+ */
+class RestInterceptor
+{
+    public function __invoke(callable $nextHandler)
+    {
+        return function (RequestInterface $request, array $options) use ($nextHandler) {
+            return $nextHandler($request, $options);
+        };
+    }
+}

--- a/tests/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/Tests/Unit/Transport/RestTransportTest.php
@@ -38,6 +38,7 @@ use Google\ApiCore\RequestBuilder;
 use Google\ApiCore\Tests\Unit\TestTrait;
 use Google\ApiCore\Testing\MockRequest;
 use Google\ApiCore\Testing\MockResponse;
+use Google\ApiCore\Transport\Rest\RestInterceptor;
 use Google\ApiCore\Transport\RestTransport;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
 use Google\Protobuf\Any;
@@ -48,6 +49,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
 
 class RestTransportTest extends TestCase
 {
@@ -77,7 +80,7 @@ class RestTransportTest extends TestCase
 
         return new RestTransport(
             $requestBuilder,
-            $httpHandler ?: HttpHandlerFactory::build()
+            $httpHandler ?: HttpHandlerFactory::build(),
         );
     }
 
@@ -337,6 +340,13 @@ class RestTransportTest extends TestCase
         $restConfigPath = __DIR__ . '/../testdata/test_service_rest_client_config.php';
         $requestBuilder = new RequestBuilder($apiEndpoint, $restConfigPath);
         $httpHandler = [HttpHandlerFactory::build(), 'async'];
+        $interceptors = [new RestInterceptor, new RestInterceptor, new RestInterceptor];
+        $stack = HandlerStack::create();
+            foreach ($interceptors as $interceptor) {
+                $stack->push($interceptor);
+            }
+        $client = new Client(['handler' => $stack]);
+        $httpHandlerInterceptor = [HttpHandlerFactory::build($client), 'async'];
         return [
             [
                 $apiEndpoint,
@@ -349,6 +359,18 @@ class RestTransportTest extends TestCase
                 $restConfigPath,
                 [],
                 new RestTransport($requestBuilder, $httpHandler),
+            ],
+            [
+                $apiEndpoint,
+                $restConfigPath,
+                ['httpHandler' => $httpHandler, 'interceptors' => $interceptors],
+                new RestTransport($requestBuilder, $httpHandler)
+            ],
+            [
+                $apiEndpoint,
+                $restConfigPath,
+                ['interceptors' => $interceptors],
+                new RestTransport($requestBuilder, $httpHandlerInterceptor)
             ],
         ];
     }
@@ -495,5 +517,120 @@ class RestTransportTest extends TestCase
 
         $this->getTransport()
             ->startUnaryCall($this->call, $options);
+    }
+
+    public function testStartUnaryCallWithInterceptor()
+    {
+        $expectedBody = ['name' => 'first-inserted-value', 'number' => 15];
+        
+        $mock = function (RequestInterface $req, array $options)
+        {
+            $body = ['name' => $options['first-test-interceptor-insert'], 'number' => $options['second-test-interceptor-insert']];
+            return Create::promiseFor(
+                new Response(
+                    200,
+                    [],
+                    json_encode($body)
+                )
+            );
+        };
+        $handler = HandlerStack :: create ($mock);
+        $handler->push(new FirstTestRestInterceptor);
+        $handler->push(new SecondTestRestInterceptor);
+        
+        $response = $this->getTransport($handler)
+            ->startUnaryCall($this->call, [])
+            ->wait();
+        
+        $this->assertEquals($expectedBody['name'], $response->getName());
+        $this->assertEquals($expectedBody['number'], $response->getNumber());
+    }
+
+/**
+     * @dataProvider buildServerStreamWithInterceptorMessages
+     */
+    public function testStartServerStreamingCallWithInterceptor($messages)
+    {
+        $mock = function (RequestInterface $request, array $options = []) {
+            $messagesToUse = [
+                new MockResponse([
+                    'name' => $options['first-test-interceptor-insert'],
+                    'number' => 1,
+                ]),
+                new MockResponse([
+                    'name' => 'bar',
+                    'number' => $options['second-test-interceptor-insert'],
+                ]),
+                new MockResponse([
+                    'name' => $options['first-test-interceptor-insert'],
+                    'number' => $options['second-test-interceptor-insert'],
+                ]),
+            ];
+            return Create::promiseFor(
+                new Response(
+                    200,
+                    [],
+                    $this->encodeMessages($messagesToUse)
+                )
+            );
+        };
+
+        $handler = HandlerStack :: create ($mock);
+        $handler->push(new FirstTestRestInterceptor);
+        $handler->push(new SecondTestRestInterceptor);
+        
+        $stream = $this->getTransport($handler)
+            ->startServerStreamingCall($this->call, []);
+
+        $num = 0;
+        foreach ($stream->readAll() as $m) {
+            $this->assertEquals($messages[$num], $m);
+            $num++;
+        }
+        $this->assertEquals(count($messages), $num);
+    }
+
+    public function buildServerStreamWithInterceptorMessages()
+    {
+        return[
+            [
+                [
+                    new MockResponse([
+                        'name' => 'first-inserted-value',
+                        'number' => 1,
+                    ]),
+                    new MockResponse([
+                        'name' => 'bar',
+                        'number' => 15,
+                    ]),
+                    new MockResponse([
+                        'name' => 'first-inserted-value',
+                        'number' => 15,
+                    ]),
+                ]
+            ]
+        ];
+    }
+}
+
+class FirstTestRestInterceptor extends RestInterceptor{
+
+    public function __invoke(callable $nextHandler)
+    {
+        return function (RequestInterface $request, array $options) use ($nextHandler) {
+            $options['first-test-interceptor-insert'] = 'first-inserted-value';
+            return $nextHandler($request, $options);
+        };
+    }
+}
+
+class SecondTestRestInterceptor extends RestInterceptor{
+
+    public function __invoke(callable $nextHandler)
+    {
+        return function (RequestInterface $request, array $options) use ($nextHandler) {
+            $options['second-test-interceptor-insert'] = 15;
+            return $nextHandler($request, $options);
+        };
     }
 }


### PR DESCRIPTION
Interceptors are a gRPC feature that wraps RPCs in
continuation-passing-style pre and post method custom functions.
These can be used e.g. for logging, local caching, and tweaking
metadata.

This PR adds interceptor-like functionality to the REST transport. Note that when an end user constructs the REST transport, they should either pass in the interceptors they want to use, OR pass through a custom httpHandler which already includes the interceptors they want to use. The REST transport will ignore any passed interceptors if there is httpHandler passed through the transport config. 

The REST transport interceptors differ from GRPC transport interceptors in a few ways:

* They are not continuations. Instead, they mimic `Middleware` [https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html] which is a concept that already exists in Guzzle and should be familiar to the PHP community.

* Existing gRPC interceptors and the new REST interceptors are not
composable or interoperable.


Should enable https://github.com/googleapis/gax-php/issues/234, although will require some work from the Ads team to implement. 
