### PR TITLE
Don't override ApiException::__toString

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -326,12 +326,4 @@ class ApiException extends Exception
         return $this->metadata;
     }
 
-    /**
-     * String representation of ApiException
-     * @return string
-     */
-    public function __toString()
-    {
-        return __CLASS__ . ": $this->message\n";
-    }
 }


### PR DESCRIPTION
Since ApiException overrides the __toString method, it does not behave as one might expect other Exception subclasses to behave. Stop overriding it so that we have more "conventional" php behavior. In particular, the backtrace will now be part of the string.

Before:
```
php > require 'src/ApiException.php';
php > $e = new \Google\ApiCore\ApiException('test_message', 1, 'test_status');
php > var_dump("$e");
string(42) "Google\ApiCore\ApiException: test_message
"
```

After:
```
php > $e = new \Google\ApiCore\ApiException('test',1,'test');
php > $e = new \Google\ApiCore\ApiException('test_message', 1, 'test_status');
php > var_dump("$e");
string(84) "Google\ApiCore\ApiException: test_message in php shell code:1
Stack trace:
#0 {main}"
```