### PR TITLE
chore: remove PHP 5.5 support

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,7 +5,6 @@ branchProtectionRules:
 - pattern: main
   isAdminEnforced: true
   requiredStatusCheckContexts:
-    - 'PHP 5.5 Unit Test'
     - 'PHP 5.6 Unit Test'
     - 'PHP 5.6 Unit Test protobuf-3.12.2,grpc'
     - 'PHP 7.0 Unit Test'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ 5.5, 5.6, "7.0", 7.1, 7.2, 7.3 ]
+                php: [ 5.6, "7.0", 7.1, 7.2, 7.3 ]
                 extensions: [""]
                 tools: [""]
                 include:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ more convenient and idiomatic API surface to callers.
 
 ## PHP Versions
 
-gax-php currently requires PHP 5.5 or higher.
+gax-php currently requires PHP 5.6 or higher.
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/googleapis/gax-php",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=5.5",
+        "php": ">=5.6",
         "google/auth": "^1.18.0",
         "google/grpc-gcp": "^0.2",
         "grpc/grpc": "^1.13",


### PR DESCRIPTION
Related to https://github.com/googleapis/gax-php/pull/389

Drop support for PHP 5.5 to make testing easier, and because it's really old

PHP Support across PHP libraries as of this moment:
 - `google/gax` (this library): PHP 5.5
 - `google/cloud`: PHP 5.5 (with the exception of Compute and SqlAdmin)
 - `google/apiclient`: PHP 5.6
 - `google/auth`: PHP 7.1