### PR TITLE
chore: fix docs workflow and add workflow_dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,10 +3,11 @@ on:
     push:
         tags:
             - "*"
+    workflow_dispatch:
 jobs:
     docs:
         name: "Generate and Deploy Documentation"
-        runs-on: ubuntu-16.04
+        runs-on: ubuntu-latest
         steps:
         - name: Checkout
           uses: actions/checkout@v3


### PR DESCRIPTION
Our docs haven't published since `v1.6.1` because the ubuntu version we were using was deprecated.

Also, if we add `workflow_dispatch` we can run the documentation from the Actions UI