### PR TITLE
chore: fix docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,10 @@ jobs:
         - id: getTag
           name: Get Tag
           run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: 7.4
         - name: Install composer dependencies
           uses: nick-invision/retry@v2
           with:
@@ -21,7 +25,7 @@ jobs:
             max_attempts: 3
             command: composer install
         - name: Generate Documentation
-          uses: docker://php:7.2-cli
+          uses: docker://php:7.4-cli
           with:
             entrypoint: ./dev/sh/build-docs.sh
             args: ${{ steps.getTag.outputs.tag }}

--- a/dev/sh/build-docs.sh
+++ b/dev/sh/build-docs.sh
@@ -47,8 +47,14 @@ function buildDocs() {
   API_CORE_DOCS_VERSION=${GIT_TAG_NAME} php ${DOCTUM_EXECUTABLE} update ${DOCTUM_CONFIG} -v
 }
 
-downloadDoctum
+# Remove "v" from start of string if it exists
+if [[ ${GIT_TAG_NAME::1} == "v" ]]
+then
+  GIT_TAG_NAME="${GIT_TAG_NAME:1}"
+fi
+
 checkVersionFile ${GIT_TAG_NAME}
+downloadDoctum
 buildDocs ${GIT_TAG_NAME}
 
 # Construct the base index file to redirect to the latest version of the docs.


### PR DESCRIPTION
Fixes docs generation by 
 - allowing for "v" in tags when matching the contents of the `VERSION` file (we switched to adding `v` before the release number at around `v1.7.0` to be consistent with the other libraries)
 - ensure the PHP version is consistent (and update it to 7.4)