### PR TITLE
chore: update doctum, fix phpunit warnings, fix misc typehinting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "google/protobuf": "^3.21.4",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.7.0||^2",
-        "google/common-protos": "^1.0||^2.0||^3.0",
+        "google/common-protos": "^1.3.1||^2.0||^3.0",
         "google/longrunning": "^0.2"
     },
     "require-dev": {

--- a/dev/sh/build-docs.sh
+++ b/dev/sh/build-docs.sh
@@ -24,8 +24,8 @@ function downloadDoctum() {
   # https://doctum.long-term.support/releases/5.1/VERSION
   rm -f "${DOCTUM_EXECUTABLE}"
   rm -f "${DOCTUM_EXECUTABLE}.sha256"
-  curl -# https://doctum.long-term.support/releases/5.1/doctum.phar -o "${DOCTUM_EXECUTABLE}"
-  curl -# https://doctum.long-term.support/releases/5.1/doctum.phar.sha256  -o "${DOCTUM_EXECUTABLE}.sha256"
+  curl -# https://doctum.long-term.support/releases/5.5/doctum.phar -o "${DOCTUM_EXECUTABLE}"
+  curl -# https://doctum.long-term.support/releases/5.5/doctum.phar.sha256  -o "${DOCTUM_EXECUTABLE}.sha256"
   sha256sum --strict --check "${DOCTUM_EXECUTABLE}.sha256"
   rm -f "${DOCTUM_EXECUTABLE}.sha256"
 }

--- a/src/BidiStream.php
+++ b/src/BidiStream.php
@@ -79,11 +79,11 @@ class BidiStream
     /**
      * Write all requests in $requests.
      *
-     * @param mixed[] $requests An Iterable of request objects to write to the server
+     * @param iterable $requests An Iterable of request objects to write to the server
      *
      * @throws ValidationException
      */
-    public function writeAll(array $requests = [])
+    public function writeAll($requests = [])
     {
         foreach ($requests as $request) {
             $this->write($request);

--- a/src/Testing/MockStubTrait.php
+++ b/src/Testing/MockStubTrait.php
@@ -33,8 +33,8 @@
 namespace Google\ApiCore\Testing;
 
 use Google\Protobuf\Internal\Message;
-use Google\Rpc\Status;
 use UnderflowException;
+use stdClass;
 
 /**
  * The MockStubTrait is used by generated mock stub classes which extent \Grpc\BaseStub
@@ -194,9 +194,9 @@ trait MockStubTrait
      * Add a response object, and an optional status, to the list of responses to be returned via
      * _simpleRequest.
      * @param \Google\Protobuf\Internal\Message $response
-     * @param Status $status
+     * @param stdClass $status
      */
-    public function addResponse($response, $status = null)
+    public function addResponse($response, stdClass $status = null)
     {
         if (!$this->deserialize && $response) {
             $this->deserialize = [get_class($response), 'decode'];
@@ -211,9 +211,9 @@ trait MockStubTrait
     /**
      * Set the status object to be used when creating streaming calls.
      *
-     * @param Status $status
+     * @param stdClass $status
      */
-    public function setStreamingStatus(Status $status)
+    public function setStreamingStatus(stdClass $status)
     {
         $this->serverStreamingStatus = $status;
     }
@@ -259,11 +259,11 @@ trait MockStubTrait
 
     /**
      * @param mixed $responseObject
-     * @param Status|null $status
+     * @param stdClass|null $status
      * @param callable $deserialize
      * @return static An instance of the current class type.
      */
-    public static function create($responseObject, Status $status = null, callable $deserialize = null)
+    public static function create($responseObject, stdClass $status = null, callable $deserialize = null)
     {
         $stub = new static($deserialize); // @phpstan-ignore-line
         $stub->addResponse($responseObject, $status);
@@ -274,10 +274,10 @@ trait MockStubTrait
      * Creates a sequence such that the responses are returned in order.
      * @param mixed[] $sequence
      * @param callable $deserialize
-     * @param Status $finalStatus
+     * @param stdClass $finalStatus
      * @return static An instance of the current class type.
      */
-    public static function createWithResponseSequence(array $sequence, callable $deserialize = null, Status $finalStatus = null)
+    public static function createWithResponseSequence(array $sequence, callable $deserialize = null, stdClass $finalStatus = null)
     {
         $stub = new static($deserialize); // @phpstan-ignore-line
         foreach ($sequence as $elem) {

--- a/tests/Tests/Unit/GrpcSupportTraitTest.php
+++ b/tests/Tests/Unit/GrpcSupportTraitTest.php
@@ -33,6 +33,7 @@ class GrpcSupportTraitTest extends TestCase
     {
         self::$hasGrpc = true;
         self::validateGrpcSupport();
+        $this->assertTrue(true);
     }
 
     public function testValidateGrpcSupportFailure()


### PR DESCRIPTION
 - Update doctum version for PHP 8.1 in #409 
 - fix skipped PHP tests
 - fix misc type-hinting issues from `google/cloud` tests
 - updates minimum common protos version