### PR TITLE
fix: use responseType for custom operations

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -589,7 +589,10 @@ trait GapicClientTrait
                 $optionalArgs,
                 $request,
                 $this->getOperationsClient(),
-                $interfaceName
+                $interfaceName,
+                // Custom operations will define their own operation response type, whereas standard
+                // LRO defaults to the same type.
+                $method['responseType'] ?? null
             );
         }
 


### PR DESCRIPTION
This just applies to `startApiCall` which is not in use anywhere yet.