### PR TITLE
chore: add phpspec prophecy to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "phpunit/phpunit": "^5.5||^8.5",
         "squizlabs/php_codesniffer": "3.*",
-        "yoast/phpunit-polyfills": "^1.0"
+        "yoast/phpunit-polyfills": "^1.0",
+        "phpspec/prophecy": "^1.10"
     },
     "conflict": {
         "ext-protobuf": "<3.7.0"


### PR DESCRIPTION
The latest versions of `phpunit` require `phpspec/prophecy` as a separate package