### PR TITLE
fix: add eager threshold

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -57,6 +57,9 @@ class CredentialsWrapper
     private $credentialsFetcher;
     private $authHttpHandler;
 
+    /** @var int */
+    private static $eagerRefreshThresholdSeconds = 10;
+
     /**
      * CredentialsWrapper constructor.
      * @param FetchAuthTokenInterface $credentialsFetcher A credentials loader
@@ -297,6 +300,6 @@ class CredentialsWrapper
     {
         return !(self::isValid($token)
             && array_key_exists('expires_at', $token)
-            && $token['expires_at'] > time());
+            && $token['expires_at'] > time() + self::$eagerRefreshThresholdSeconds);
     }
 }

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -206,6 +206,17 @@ class CredentialsWrapperTest extends TestCase
                 'access_token' => 456,
                 'expires_at' => time() + 1000
             ]);
+        $eagerExpiredFetcher = $this->prophesize(FetchAuthTokenInterface::class);
+        $eagerExpiredFetcher->getLastReceivedToken()
+            ->willReturn([
+                'access_token' => 123,
+                'expires_at' => time() + 1
+            ]);
+        $eagerExpiredFetcher->fetchAuthToken(Argument::any())
+            ->willReturn([
+                'access_token' => 456,
+                'expires_at' => time() + 10 // within 10 second eager threshold
+            ]);
         $unexpiredFetcher = $this->prophesize(FetchAuthTokenInterface::class);
         $unexpiredFetcher->getLastReceivedToken()
             ->willReturn([
@@ -226,6 +237,7 @@ class CredentialsWrapperTest extends TestCase
             ]);
         return [
             [$expiredFetcher->reveal(), 'Bearer 456'],
+            [$eagerExpiredFetcher->reveal(), 'Bearer 456'],
             [$unexpiredFetcher->reveal(), 'Bearer 123'],
             [$insecureFetcher->reveal(), ''],
             [$nullFetcher->reveal(), '']

--- a/tests/Tests/Unit/OperationResponseTest.php
+++ b/tests/Tests/Unit/OperationResponseTest.php
@@ -377,7 +377,7 @@ class FakeOperationResponse extends OperationResponse
         return $this->sleeps;
     }
 
-    public function sleepMillis($millis)
+    public function sleepMillis(int $millis)
     {
         $this->currentTime += $millis;
         $this->sleeps[] = $millis;


### PR DESCRIPTION
Similar to [NodeJS's eager threshold](https://github.com/googleapis/google-auth-library-nodejs/blob/883cf2596664b7de8159fb29a8f16705218a2ad4/src/auth/jwtaccess.ts#L108), add an eager threshold in order to refresh tokens a little bit early and prevent issues judged by clocks being slightly off, or race conditions.