### PR TITLE
fix: use interfaceOverride instead of param

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -530,7 +530,6 @@ trait GapicClientTrait
 
     /**
      * @param string $methodName
-     * @param string $interfaceName
      * @param Message $request
      * @param array $optionalArgs {
      *     Call Options
@@ -548,7 +547,6 @@ trait GapicClientTrait
      */
     private function startApiCall(
         string $methodName,
-        string $interfaceName = null,
         Message $request = null,
         array $optionalArgs = []
     ) {
@@ -565,7 +563,7 @@ trait GapicClientTrait
         $optionalArgs['headers'] = array_merge($requestHeaders, $optionalArgs['headers'] ?? []);
 
         // Default the interface name, if not set, to the client's protobuf service name.
-        $interfaceName = $interfaceName ?: $this->serviceName;
+        $interfaceName = $method['interfaceOverride'] ?? $this->serviceName;
 
         // Handle call based on call type configured in the method descriptor config.
         if (!isset($method['callType'])) {

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -130,7 +130,6 @@ class GapicClientTraitTest extends TestCase
         $client->set('descriptors', ['method' => $unaryDescriptors]);
         $client->call('startApiCall', [
             'method',
-            null,
             $request,
             ['headers' => $headers]
         ]);
@@ -259,7 +258,6 @@ class GapicClientTraitTest extends TestCase
         $request = new MockRequest();
         $response = $client->call('startApiCall', [
             'method',
-            /* interfaceName */ null,
             $request
         ])->wait();
 
@@ -312,7 +310,6 @@ class GapicClientTraitTest extends TestCase
         $request = new MockRequest();
         $response = $client->call('startApiCall', [
             'method',
-            /* interfaceName */ null,
             $request,
         ])->wait();
 
@@ -340,7 +337,6 @@ class GapicClientTraitTest extends TestCase
 
         $client->call('startApiCall', [
             'method',
-            /* interfaceName */ null,
             new MockRequest()
         ])->wait();
     }
@@ -411,7 +407,6 @@ class GapicClientTraitTest extends TestCase
         $request = new MockRequest();
         $client->call('startApiCall', [
             'method',
-            /* interfaceName */ null,
             $request
         ])->wait();
     }
@@ -450,7 +445,6 @@ class GapicClientTraitTest extends TestCase
         $request = new MockRequest();
         $client->call('startApiCall', [
             'method',
-            /* interfaceName */ null,
             $request
         ]);
     }


### PR DESCRIPTION
We will start generating the an `interfaceOverride` descriptor config as part of https://github.com/googleapis/gapic-generator-php/pull/510 which will take the place of the `interfaceName` parameter on `startApiCall`. This will allow `sendAsync`/`startAsynCall` to also exclude the `interfaceName`, a param the user should not have to set.

Doing this change now with `startApiCall` allows for a patch release which we can then use for testing https://github.com/googleapis/gapic-generator-php/pull/510 in.