### PR TITLE
chore(docs): preserve exact tag name for correct links

### DIFF
--- a/dev/sh/build-docs.sh
+++ b/dev/sh/build-docs.sh
@@ -48,12 +48,13 @@ function buildDocs() {
 }
 
 # Remove "v" from start of string if it exists
+GIT_TAG_NUMBER=$GIT_TAG_NAME
 if [[ ${GIT_TAG_NAME::1} == "v" ]]
 then
-  GIT_TAG_NAME="${GIT_TAG_NAME:1}"
+  GIT_TAG_NUMBER="${GIT_TAG_NAME:1}"
 fi
 
-checkVersionFile ${GIT_TAG_NAME}
+checkVersionFile ${GIT_TAG_NUMBER}
 downloadDoctum
 buildDocs ${GIT_TAG_NAME}
 


### PR DESCRIPTION
Without this, the "view source" link on any docs page with the tag name starting with `v` (so, all of our most recent tags) results in a 404.

For example, see https://googleapis.github.io/gax-php/1.17.0/Google/ApiCore/AgentHeader.html