### PR TITLE
chore(docs): ensure generated protobuf docs uses supplied version

### DIFF
--- a/dev/sh/build-protobuf-docs.sh
+++ b/dev/sh/build-protobuf-docs.sh
@@ -42,8 +42,11 @@ function buildDocs() {
   DOCTUM_CONFIG=${ROOT_DIR}/dev/src/Docs/doctum-protobuf-config.php
   PROTOBUF_DOCS_VERSION=${GIT_TAG_NAME} php ${DOCTUM_EXECUTABLE} update ${DOCTUM_CONFIG} -v
 }
-
+# ensure we have the correct version of protobuf
+composer update google/protobuf:$GIT_TAG_NAME
+# download doctum.phar
 downloadDoctum
+# build the docs
 buildDocs ${GIT_TAG_NAME}
 
 # Construct the base index file to redirect to the Protobuf namespace


### PR DESCRIPTION
Fix issue where user supplied tag can be a mismatch from the actual protobuf version (see cl/496981224)