### PR TITLE
fix: ensure metadata return type is loaded into descriptor pool

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -765,6 +765,7 @@ trait GapicClientTrait
             'transportOptions',
             'metadataCallback',
             'audience',
+            'metadataReturnType'
         ]);
 
         return $callStack;
@@ -827,8 +828,8 @@ trait GapicClientTrait
         $callStack = $this->createCallStack(
             $this->configureCallConstructionOptions($methodName, $optionalArgs)
         );
-
         $descriptor = $this->descriptors[$methodName]['longRunning'];
+        $metadataReturnType = null;
 
         // Call the methods supplied in "additionalArgumentMethods" on the request Message object
         // to build the "additionalOperationArguments" option for the operation response.
@@ -839,6 +840,10 @@ trait GapicClientTrait
             }
             $descriptor['additionalOperationArguments'] = $additionalArgs;
             unset($descriptor['additionalArgumentMethods']);
+        }
+
+        if (isset($descriptor['metadataReturnType'])) {
+            $metadataReturnType = $descriptor['metadataReturnType'];
         }
 
         $callStack = new OperationsMiddleware($callStack, $client, $descriptor);
@@ -853,6 +858,7 @@ trait GapicClientTrait
 
         $this->modifyUnaryCallable($callStack);
         return $callStack($call, $optionalArgs + array_filter([
+            'metadataReturnType' => $metadataReturnType,
             'audience' => self::getDefaultAudience()
         ]));
     }

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -1208,7 +1208,8 @@ class GapicClientTraitTest extends TestCase
                     'headers' => AgentHeader::buildAgentHeader([]),
                     'credentialsWrapper' => CredentialsWrapper::build([
                         'keyFile' => __DIR__ . '/testdata/json-key-file.json'
-                    ])
+                    ]),
+                    'metadataReturnType' => 'metadataType'
                 ])
             )
             ->willReturn(new FulfilledPromise(new Operation()));
@@ -1471,6 +1472,7 @@ class GapicClientTraitTest extends TestCase
                     'audience' => 'https://service-address/',
                     'headers' => [],
                     'credentialsWrapper' => $credentialsWrapper,
+                    'metadataReturnType' => 'metadataType'
                 ]
             )
             ->shouldBeCalledOnce()

--- a/tests/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/Tests/Unit/Transport/RestTransportTest.php
@@ -146,6 +146,9 @@ class RestTransportTest extends TestCase
             ->wait();
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testStartUnaryCallWithValidProtoNotLoadedInDescPool()
     {
         $endpoint = 'www.example.com';
@@ -192,6 +195,9 @@ class RestTransportTest extends TestCase
         );
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testStartUnaryCallWithValidProtoNotLoadedInDescPoolThrowsExWithoutMetadataType()
     {
         $endpoint = 'www.example.com';
@@ -206,7 +212,7 @@ class RestTransportTest extends TestCase
             'metadata' => [
                 // This type is arbitrarily chosen and should not exist within the descriptor pool
                 // upon instantation of this test.
-                '@type' => 'type.googleapis.com/google.type.TimeOfDay'
+                '@type' => 'type.googleapis.com/google.type.DateTime'
             ]
         ];
         $httpHandler = function (RequestInterface $request) use ($body, $expectedRequest) {

--- a/tests/Tests/Unit/Transport/RestTransportTest.php
+++ b/tests/Tests/Unit/Transport/RestTransportTest.php
@@ -44,8 +44,10 @@ use Google\ApiCore\Tests\Unit\TestTrait;
 use Google\ApiCore\Transport\RestTransport;
 use Google\ApiCore\ValidationException;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
+use Google\LongRunning\Operation;
 use Google\Protobuf\Any;
 use Google\Rpc\ErrorInfo;
+use Google\Type\DateTime;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Psr7\Request;
@@ -141,6 +143,91 @@ class RestTransportTest extends TestCase
 
         $this->getTransport($httpHandler)
             ->startUnaryCall($this->call, [])
+            ->wait();
+    }
+
+    public function testStartUnaryCallWithValidProtoNotLoadedInDescPool()
+    {
+        $endpoint = 'www.example.com';
+        $expectedRequest = new Request(
+            'POST',
+            $endpoint,
+            [],
+            ''
+        );
+        $body = [
+            'name' => 'projects/my-project/locations/us-central1/operations/my-operation',
+            'metadata' => [
+                // This type is arbitrarily chosen and should not exist within the descriptor pool
+                // upon instantation of this test.
+                '@type' => 'type.googleapis.com/google.type.DateTime'
+            ]
+        ];
+        $httpHandler = function (RequestInterface $request) use ($body, $expectedRequest) {
+            $this->assertEquals($expectedRequest, $request);
+            return Create::promiseFor(
+                new Response(
+                    200,
+                    [],
+                    json_encode($body)
+                )
+            );
+        };
+        $call = new Call(
+            'Testing123',
+            Operation::class,
+            new MockRequest()
+        );
+
+        $response = $this->getTransport($httpHandler, $endpoint)
+            ->startUnaryCall($call, [
+                'metadataReturnType' => DateTime::class
+            ])
+            ->wait();
+
+        $this->assertInstanceOf(Operation::class, $response);
+        $this->assertEquals(
+            $body['metadata']['@type'],
+            $response->getMetadata()->getTypeUrl()
+        );
+    }
+
+    public function testStartUnaryCallWithValidProtoNotLoadedInDescPoolThrowsExWithoutMetadataType()
+    {
+        $endpoint = 'www.example.com';
+        $expectedRequest = new Request(
+            'POST',
+            $endpoint,
+            [],
+            ''
+        );
+        $body = [
+            'name' => 'projects/my-project/locations/us-central1/operations/my-operation',
+            'metadata' => [
+                // This type is arbitrarily chosen and should not exist within the descriptor pool
+                // upon instantation of this test.
+                '@type' => 'type.googleapis.com/google.type.TimeOfDay'
+            ]
+        ];
+        $httpHandler = function (RequestInterface $request) use ($body, $expectedRequest) {
+            $this->assertEquals($expectedRequest, $request);
+            return Create::promiseFor(
+                new Response(
+                    200,
+                    [],
+                    json_encode($body)
+                )
+            );
+        };
+        $call = new Call(
+            'Testing123',
+            Operation::class,
+            new MockRequest()
+        );
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches('/^Error occurred during parsing:/');
+        $this->getTransport($httpHandler, $endpoint)
+            ->startUnaryCall($call, [])
             ->wait();
     }
 


### PR DESCRIPTION
There are a few rare cases where metadata return types for long running operations aren't being added into the descriptor pool when utilizing the REST transport. This fix ensures they are added by instantiating the metadata class, which triggers an `initOnce`call which loads the data into the associated pool.