### PR TITLE
fix: ensure cache is used in calls to ADC::onGCE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.0",
-        "google/auth": "^1.18.0",
+        "google/auth": "dev-add-get-fetcher as 1.25.0",
         "google/grpc-gcp": "^0.2",
         "grpc/grpc": "^1.13",
         "google/protobuf": "^3.21.4",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.0",
-        "google/auth": "dev-add-get-fetcher as 1.25.0",
+        "google/auth": "1.19.1||^1.25.0",
         "google/grpc-gcp": "^0.2",
         "grpc/grpc": "^1.13",
         "google/protobuf": "^3.21.4",

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -122,6 +122,7 @@ class CredentialsWrapper
             'defaultScopes'     => null,
             'useJwtAccessWithScope' => true,
         ];
+
         $keyFile = $args['keyFile'];
         $authHttpHandler = $args['authHttpHandler'] ?: self::buildHttpHandlerFactory();
 
@@ -129,11 +130,14 @@ class CredentialsWrapper
             $loader = self::buildApplicationDefaultCredentials(
                 $args['scopes'],
                 $authHttpHandler,
-                null,
-                null,
+                $args['authCacheOptions'],
+                $args['authCache'],
                 $args['quotaProject'],
                 $args['defaultScopes']
             );
+            if ($loader instanceof FetchAuthTokenCache) {
+                $loader = $loader->getFetcher();
+            }
         } else {
             if (is_string($keyFile)) {
                 if (!file_exists($keyFile)) {

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -40,6 +40,7 @@ use Google\Auth\Cache\SysVCacheItemPool;
 use Google\Auth\GCECache;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\Credentials\GCECredentials;
+use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
@@ -324,6 +325,7 @@ class CredentialsWrapperTest extends TestCase
     public function testApplicationDefaultCredentialsWithOnGCECacheTrue()
     {
         putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from the environment
 
         $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
         $mockCacheItem->isHit()
@@ -352,10 +354,11 @@ class CredentialsWrapperTest extends TestCase
      */
     public function testApplicationDefaultCredentialsWithOnGCECacheFalse()
     {
+        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from the environment
+
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Could not construct ApplicationDefaultCredentials');
-
-        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
 
         $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
         $mockCacheItem->isHit()
@@ -381,6 +384,7 @@ class CredentialsWrapperTest extends TestCase
     public function testApplicationDefaultCredentialsWithOnGCECacheOptions()
     {
         putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+        putenv(ServiceAccountCredentials::ENV_VAR);  // removes it from the environment
 
         $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
         $mockCacheItem->isHit()

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -33,10 +33,13 @@
 namespace Google\ApiCore\Tests\Unit;
 
 use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\ValidationException;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\Cache\MemoryCacheItemPool;
 use Google\Auth\Cache\SysVCacheItemPool;
+use Google\Auth\GCECache;
 use Google\Auth\CredentialsLoader;
+use Google\Auth\Credentials\GCECredentials;
 use Google\Auth\FetchAuthTokenCache;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Auth\HttpHandler\HttpHandlerFactory;
@@ -313,5 +316,92 @@ class CredentialsWrapperTest extends TestCase
             [$nullFetcher->reveal(), []],
             [$customFetcher->reveal(), ['authorization' => ['Bearer 123']]],
         ];
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testApplicationDefaultCredentialsWithOnGCECacheTrue()
+    {
+        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+
+        $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $mockCacheItem->isHit()
+            ->willReturn(true);
+        // mock being on GCE
+        $mockCacheItem->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+
+        $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+        $mockCache->getItem(GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($mockCacheItem->reveal());
+
+        $wrapper = CredentialsWrapper::build([
+            'authCache' => $mockCache->reveal(),
+        ]);
+        $reflectionClass = new \ReflectionClass($wrapper);
+        $reflectionProperty = $reflectionClass->getProperty('credentialsFetcher');
+        $reflectionProperty->setAccessible(true);
+        $this->assertInstanceOf(GCECredentials::class, $reflectionProperty->getValue($wrapper)->getFetcher());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testApplicationDefaultCredentialsWithOnGCECacheFalse()
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Could not construct ApplicationDefaultCredentials');
+
+        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+
+        $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $mockCacheItem->isHit()
+            ->willReturn(true);
+        // mock not being on GCE
+        $mockCacheItem->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(false);
+
+        $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+        $mockCache->getItem(GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($mockCacheItem->reveal());
+
+        $wrapper = CredentialsWrapper::build([
+            'authCache' => $mockCache->reveal(),
+        ]);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testApplicationDefaultCredentialsWithOnGCECacheOptions()
+    {
+        putenv('HOME=' . __DIR__ . '/not_exist_fixtures');
+
+        $mockCacheItem = $this->prophesize('Psr\Cache\CacheItemInterface');
+        $mockCacheItem->isHit()
+            ->willReturn(true);
+        // mock being on GCE
+        $mockCacheItem->get()
+            ->shouldBeCalledTimes(1)
+            ->willReturn(true);
+
+        $mockCache = $this->prophesize('Psr\Cache\CacheItemPoolInterface');
+        $mockCache->getItem('prefix_' . GCECache::GCE_CACHE_KEY)
+            ->shouldBeCalledTimes(1)
+            ->willReturn($mockCacheItem->reveal());
+
+        $wrapper = CredentialsWrapper::build([
+            'authCache' => $mockCache->reveal(),
+            'authCacheOptions' => ['gce_prefix' => 'prefix_'],
+        ]);
+        $reflectionClass = new \ReflectionClass($wrapper);
+        $reflectionProperty = $reflectionClass->getProperty('credentialsFetcher');
+        $reflectionProperty->setAccessible(true);
+        $this->assertInstanceOf(GCECredentials::class, $reflectionProperty->getValue($wrapper)->getFetcher());
     }
 }


### PR DESCRIPTION
Will require an update to the minimum `google/auth` version once https://github.com/googleapis/google-auth-library-php/pull/431 is merged

 **Note**: We will also need to cherry-pick this commit into [v1.19.0](https://github.com/googleapis/google-auth-library-php/releases/tag/v1.19.0) and tag `v1.19.1` as well, in order to maintain compatibility in PHP 7.0.
 - [x] tagged [v1.25.0](https://github.com/googleapis/google-auth-library-php/releases/tag/v1.25.0)
 - [x] tagged [v1.19.1](https://github.com/googleapis/google-auth-library-php/releases/tag/v1.19.1)