### PR TITLE
chore(tests): skip v2 client tests on php 7.3 and below

### DIFF
--- a/src/Testing/GeneratedTest.php
+++ b/src/Testing/GeneratedTest.php
@@ -35,13 +35,20 @@ use Google\ApiCore\Serializer;
 use Google\Protobuf\DescriptorPool;
 use Google\Protobuf\Internal\Message;
 use Google\Protobuf\Internal\RepeatedField;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * @internal
  */
 abstract class GeneratedTest extends TestCase
 {
+    public function set_up()
+    {
+        if (false !== strpos(get_class($this), '\\Client\\') && PHP_VERSION_ID < 74000) {
+            self::markTestSkipped('The new clients are only supported on PHP 7.4+');
+        }
+    }
+
     /**
      * @param mixed $expected
      * @param mixed $actual

--- a/src/Testing/GeneratedTest.php
+++ b/src/Testing/GeneratedTest.php
@@ -37,6 +37,11 @@ use Google\Protobuf\Internal\Message;
 use Google\Protobuf\Internal\RepeatedField;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
+if (!class_exists(TestCase::class)) {
+    // If the PHPUnit polyfills are not installed, use the PHPUnit testcase
+    class_alias(\PHPUnit\Framework\TestCase::class, TestCase::class);
+}
+
 /**
  * @internal
  */

--- a/tests/Tests/Unit/Client/PretendGeneratedClientTest.php
+++ b/tests/Tests/Unit/Client/PretendGeneratedClientTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright 2017 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace Google\ApiCore\Tests\Unit\Client;;
+
+use Google\Api\Monitoring_MonitoringDestination;
+use Google\ApiCore\Testing\GeneratedTest;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit_Framework_ExpectationFailedException;
+
+class GeneratedTestTest extends GeneratedTest
+{
+    public function testOnlyRunsOnPhp74AndAbove()
+    {
+	// test this only runs on PHP 7.4+
+        $this->assertGreaterThanOrEqual(74000, PHP_VERSION_ID);
+    }
+}

--- a/tests/Tests/Unit/Client/PretendGeneratedClientTest.php
+++ b/tests/Tests/Unit/Client/PretendGeneratedClientTest.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2017 Google LLC
+ * Copyright 2023 Google LLC
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,12 +29,9 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-namespace Google\ApiCore\Tests\Unit\Client;;
+namespace Google\ApiCore\Tests\Unit\Client;
 
-use Google\Api\Monitoring_MonitoringDestination;
 use Google\ApiCore\Testing\GeneratedTest;
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit_Framework_ExpectationFailedException;
 
 class GeneratedTestTest extends GeneratedTest
 {
@@ -44,3 +41,4 @@ class GeneratedTestTest extends GeneratedTest
         $this->assertGreaterThanOrEqual(74000, PHP_VERSION_ID);
     }
 }
+


### PR DESCRIPTION
PHPUnit will skip running for any test in a subnamespace `\Client\` when on PHP 7.3 or below (see `tests/Tests/Unit/Client/PretendGeneratedClientTest.php`)

Any test extending `GeneratorTest` will runs as expected even when the `phpunit-polyfill` library isn't installed (as this dependency is not installed for all our tests).