### PR TITLE
chore: github workflows marked readOnly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
         tags:
             - "*"
     workflow_dispatch:
+permissions:
+  contents: read
 jobs:
     docs:
         name: "Generate and Deploy Documentation"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Following up on Step Security's suggestions to restrict permissions for `GITHUB_TOKEN`.