### PR TITLE
feat: add support for quota project env var

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -268,7 +268,7 @@ class CredentialsWrapper
                 $authHttpHandler,
                 $authCacheOptions,
                 $authCache,
-                $quotaProject,
+                $quotaProject ?: self::getQuotaProjectFromEnvVar(),
                 $defaultScopes
             );
         } catch (DomainException $ex) {
@@ -305,5 +305,13 @@ class CredentialsWrapper
         return !(self::isValid($token)
             && array_key_exists('expires_at', $token)
             && $token['expires_at'] > time() + self::$eagerRefreshThresholdSeconds);
+    }
+
+    /**
+     * @return string|null
+     */
+    private static function getQuotaProjectFromEnvVar()
+    {
+        return getenv('GOOGLE_CLOUD_QUOTA_PROJECT') ?: null;
     }
 }

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -74,6 +74,28 @@ class CredentialsWrapperTest extends TestCase
         $this->assertEquals($expectedCredentialsWrapper, $actualCredentialsWrapper);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testQuotaProjectPrecedence()
+    {
+        // Set keyfile to ensure quota project comes from the JSON file
+        putenv('GOOGLE_APPLICATION_CREDENTIALS=' . __DIR__ . '/testdata/json-key-file-with-quota-project.json');
+        $credentialsWrapper = CredentialsWrapper::build();
+        $this->assertEquals('example_quota_project', $credentialsWrapper->getQuotaProject());
+
+        // Now set the quota project env var to ensure it overrides the JSON file
+        putenv('GOOGLE_CLOUD_QUOTA_PROJECT=quota_project_from_env');
+        $credentialsWrapper = CredentialsWrapper::build();
+        $this->assertEquals('quota_project_from_env', $credentialsWrapper->getQuotaProject());
+
+        // Now pass the quota project through the build method to ensure it overrides the env var
+        $credentialsWrapper = CredentialsWrapper::build([
+            'quotaProject' => 'quota_project_from_build_method'
+        ]);
+        $this->assertEquals('quota_project_from_build_method', $credentialsWrapper->getQuotaProject());
+    }
+
     public function buildDataWithoutExplicitKeyFile()
     {
         $appDefaultCreds = getenv('GOOGLE_APPLICATION_CREDENTIALS');

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -89,23 +89,30 @@ class CredentialsWrapperTest extends TestCase
         $credentialsWrapper = CredentialsWrapper::build();
         $this->assertEquals('quota_project_from_env', $credentialsWrapper->getQuotaProject());
 
-        // Now pass the quota project through the build method to ensure it overrides the env var
+        // Now pass the quota project as a client option to ensure it overrides the env var
         $credentialsWrapper = CredentialsWrapper::build([
-            'quotaProject' => 'quota_project_from_build_method'
+            'quotaProject' => 'quota_project_from_client_option'
         ]);
-        $this->assertEquals('quota_project_from_build_method', $credentialsWrapper->getQuotaProject());
+        $this->assertEquals('quota_project_from_client_option', $credentialsWrapper->getQuotaProject());
 
-        // Now pass the keyFile parameter with no value for "quota_project_id", and it will be null
+        // Now pass the keyFile option with no value for "quota_project_id", and it will be null
         $credentialsWrapper = CredentialsWrapper::build([
             'keyFile' => __DIR__ . '/testdata/json-key-file.json'
         ]);
         $this->assertEquals(null, $credentialsWrapper->getQuotaProject());
 
-        // Now pass the keyFile parameter with a value for "quota_project_id", and it will be that value
+        // Now pass the keyFile option with a value for "quota_project_id", and it will be that value
         $credentialsWrapper = CredentialsWrapper::build([
             'keyFile' => __DIR__ . '/testdata/json-key-file-with-quota-project.json'
         ]);
         $this->assertEquals('example_quota_project', $credentialsWrapper->getQuotaProject());
+
+        // Now pass a quotaProject options with the keyFile option, and ensure it overrides the keyFile
+        $credentialsWrapper = CredentialsWrapper::build([
+            'keyFile' => __DIR__ . '/testdata/json-key-file-with-quota-project.json',
+            'quotaProject' => 'quota_project_from_client_option',
+        ]);
+        $this->assertEquals('quota_project_from_client_option', $credentialsWrapper->getQuotaProject());
     }
 
     public function buildDataWithoutExplicitKeyFile()

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -94,6 +94,18 @@ class CredentialsWrapperTest extends TestCase
             'quotaProject' => 'quota_project_from_build_method'
         ]);
         $this->assertEquals('quota_project_from_build_method', $credentialsWrapper->getQuotaProject());
+
+        // Now pass the keyFile parameter with no value for "quota_project_id", and it will be null
+        $credentialsWrapper = CredentialsWrapper::build([
+            'keyFile' => __DIR__ . '/testdata/json-key-file.json'
+        ]);
+        $this->assertEquals(null, $credentialsWrapper->getQuotaProject());
+
+        // Now pass the keyFile parameter with a value for "quota_project_id", and it will be that value
+        $credentialsWrapper = CredentialsWrapper::build([
+            'keyFile' => __DIR__ . '/testdata/json-key-file-with-quota-project.json'
+        ]);
+        $this->assertEquals('example_quota_project', $credentialsWrapper->getQuotaProject());
     }
 
     public function buildDataWithoutExplicitKeyFile()

--- a/tests/Tests/Unit/testdata/json-key-file-with-quota-project.json
+++ b/tests/Tests/Unit/testdata/json-key-file-with-quota-project.json
@@ -1,0 +1,8 @@
+{
+    "type": "authorized_user",
+    "client_id": "example@example.com",
+    "client_secret": "example",
+    "refresh_token": "abc",
+    "project_id": "example_project",
+    "quota_project_id": "example_quota_project"
+}


### PR DESCRIPTION
Alternative implementation to https://github.com/googleapis/google-auth-library-php/pull/452/files

This works:
```php
putenv('GOOGLE_CLOUD_QUOTA_PROJECT=my-quota-project');
// outputs "my-quota-project"
echo CredentialsWrapper::build()->getQuotaProject();
```
This does not:
```php
putenv('GOOGLE_CLOUD_QUOTA_PROJECT=my-quota-project');
// outputs value of "quota_project_id" in the JSON keyfile, or null if one doesn't exist
echo CredentialsWrapper::build(['keyFile' => $keyFilePath])->getQuotaProject(); 
```
But this does:
```php
putenv('GOOGLE_CLOUD_QUOTA_PROJECT=my-quota-project');
putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $keyFilePath);
// outputs "my-quota-project" regardless of what is in the JSON keyfile
echo CredentialsWrapper::build()->getQuotaProject(); 
```

cc @TimurSadykov