### PR TITLE
fix: ensure timeout set by RetryMiddleware is int not float

### DIFF
--- a/src/Middleware/RetryMiddleware.php
+++ b/src/Middleware/RetryMiddleware.php
@@ -128,7 +128,7 @@ class RetryMiddleware
         }
 
         $delayMs = min($delayMs * $delayMult, $maxDelayMs);
-        $timeoutMs = min(
+        $timeoutMs = (int) min(
             $timeoutMs * $timeoutMult,
             $maxTimeoutMs,
             $deadlineMs - $this->getCurrentTimeMs()

--- a/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
+++ b/tests/Tests/Unit/Middleware/RetryMiddlewareTest.php
@@ -40,6 +40,7 @@ use Google\ApiCore\RetrySettings;
 use Google\Rpc\Code;
 use GuzzleHttp\Promise\Promise;
 use PHPUnit\Framework\TestCase;
+use function usleep;
 
 class RetryMiddlewareTest extends TestCase
 {
@@ -226,6 +227,9 @@ class RetryMiddlewareTest extends TestCase
             $callCount += 1;
             $observedTimeouts[] = $options['timeoutMillis'];
             return $promise = new Promise(function () use (&$promise, $callCount) {
+                // each call needs to take at least 1 millisecond otherwise the rounded timeout will not decrease
+                // with each step of the test.
+                usleep(1000);
                 if ($callCount < 3) {
                     throw new ApiException('Cancelled!', Code::CANCELLED, ApiStatus::CANCELLED);
                 }


### PR DESCRIPTION
RetrySettings/RetryMiddleware supports a totalTimeoutMs option which caps the overall timeout for all retries. At the moment, when this is active it can result in RetryMiddleware calculating that the timeout for the next call should be a floating point value.

This is because the calculation includes the current time found by `microtime(true) * 1000`, which returns a floating point value.

When used in combination with the GRPC transport, the timeout value will eventually end up in \Grpc\AbstractCall::__construct(). That class checks that the value passes `is_numeric()` and then attempts to create `\Grpc\Timeval($timeout)`. However that class is typed to take an integer, and so PHP >= 8.1 gives a deprecation error like:

```
Implicit conversion from float 9999998.046875 to int loses precision
 in /path/to/vendor/grpc/grpc/src/lib/AbstractCall.php:55
```

Because the timeout is within an options array it is not strictly typed, but it would appear that it is always expected to be an integer.

This commit explicitly casts the calculated timeout to an int, after rounding down, which resolves the later PHP deprecation error.