### PR TITLE
feat: interface and methods for middleware stack

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -95,6 +95,23 @@ trait GapicClientTrait
      *
      *     callable(MiddlewareInterface): MiddlewareInterface
      *
+     * An implementation may look something like this:
+     * ```
+     * $client->addMiddleware(function (MiddlewareInterface $handler) {
+     *     return new class ($handler) implements MiddlewareInterface {
+     *         public function __construct(private MiddlewareInterface $handler) {
+     *         }
+     * 
+     *         public function __invoke(Call $call, array $options) {
+     *             // modify call and options (pre-request)
+     *             $response = ($this->handler)($call, $options);
+     *             // modify the response (post-request)
+     *             return $response;
+     *         }
+     *     };
+     * });
+     * ```
+     *
      * @param callable $middlewareCallable A callable which returns an instance
      *                 of {@see MiddlewareInterface} when invoked with a
      *                 MiddlewareInterface instance as its first argument.

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -32,6 +32,7 @@
 
 namespace Google\ApiCore;
 
+use Google\ApiCore\Call;
 use Google\ApiCore\LongRunning\OperationsClient;
 use Google\ApiCore\Middleware\CredentialsWrapperMiddleware;
 use Google\ApiCore\Middleware\FixedHeaderMiddleware;
@@ -75,6 +76,8 @@ trait GapicClientTrait
     private string $serviceName = '';
     private array $agentHeader = [];
     private array $descriptors = [];
+    /** @var array<callable> $middlewareCallables */
+    private array $middlewareCallables = [];
     private array $transportCallMethods = [
         Call::UNARY_CALL => 'startUnaryCall',
         Call::BIDI_STREAMING_CALL => 'startBidiStreamingCall',
@@ -82,6 +85,25 @@ trait GapicClientTrait
         Call::SERVER_STREAMING_CALL => 'startServerStreamingCall',
     ];
     private bool $isNewClient;
+
+    /**
+     * Add a middleware to the call stack by providing a callable which will be
+     * invoked at the start of each call, and will return an instance of
+     * {@see MiddlewareInterface} when invoked.
+     *
+     * The callable must have the following method signature:
+     *
+     *     callable(MiddlewareInterface): MiddlewareInterface
+     *
+     * @param callable $middlewareCallable A callable which returns an instance
+     *                 of {@see MiddlewareInterface} when invoked with a
+     *                 MiddlewareInterface instance as its first argument.
+     * @return void
+     */
+    public function addMiddleware(callable $middlewareCallable): void
+    {
+        $this->middlewareCallables[] = $middlewareCallable;
+    }
 
     /**
      * Initiates an orderly shutdown in which preexisting calls continue but new
@@ -790,6 +812,11 @@ trait GapicClientTrait
             'audience',
             'metadataReturnType'
         ]);
+
+        foreach (\array_reverse($this->middlewareCallables) as $fn) {
+            /** @var MiddlewareInterface $callStack */
+            $callStack = $fn($callStack);
+        }
 
         return $callStack;
     }

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -101,7 +101,7 @@ trait GapicClientTrait
      *     return new class ($handler) implements MiddlewareInterface {
      *         public function __construct(private MiddlewareInterface $handler) {
      *         }
-     * 
+     *
      *         public function __invoke(Call $call, array $options) {
      *             // modify call and options (pre-request)
      *             $response = ($this->handler)($call, $options);

--- a/src/Middleware/CredentialsWrapperMiddleware.php
+++ b/src/Middleware/CredentialsWrapperMiddleware.php
@@ -33,11 +33,12 @@ namespace Google\ApiCore\Middleware;
 
 use Google\ApiCore\Call;
 use Google\ApiCore\CredentialsWrapper;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
 * Middleware which adds a CredentialsWrapper object to the call options.
 */
-class CredentialsWrapperMiddleware
+class CredentialsWrapperMiddleware implements MiddlewareInterface
 {
     /** @var callable */
     private $nextHandler;

--- a/src/Middleware/FixedHeaderMiddleware.php
+++ b/src/Middleware/FixedHeaderMiddleware.php
@@ -33,11 +33,12 @@
 namespace Google\ApiCore\Middleware;
 
 use Google\ApiCore\Call;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
  * Middleware to add fixed headers to an API call.
  */
-class FixedHeaderMiddleware
+class FixedHeaderMiddleware implements MiddlewareInterface
 {
     /** @var callable */
     private $nextHandler;

--- a/src/Middleware/MiddlewareInterface.php
+++ b/src/Middleware/MiddlewareInterface.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright 2023 Google LLC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Google\ApiCore\Middleware;
+
+use Google\ApiCore\Call;
+use GuzzleHttp\Promise\PromiseInterface;
+use Google\ApiCore\ClientStream;
+use Google\ApiCore\ServerStream;
+use Google\ApiCore\BidiStream;
+
+/**
+ * Middlewares must take a MiddlewareInterface as their first constructor
+ * argument {@see Google\ApiCore\Middleware\ResponseMetadataMiddleware}, which
+ * represents the next middleware in the chain. This next middleware MUST be
+ * invoked by this MiddlewareInterface, and the result must be returned as part
+ * of the `__invoke` method implementation.
+ *
+ * To create your own middleware, first implement the interface, as well as pass the handler
+ * in through the constructor:
+ *
+ * ```
+ * use Google\ApiCore\Call;
+ * use Google\ApiCore\Middleware\MiddlewareInterface;
+ *
+ * class MyTestMiddleware implements MiddlewareInterface
+ * {
+ *     public function __construct(MiddlewareInterface $handler)
+ *      {
+ *.         $this->handler = $handler;
+ *      }
+ *      public function __invoke(Call $call, array $options)
+ *      {
+ *          echo "Logging info about the call: " . $call->getMethod();
+ *          return ($this->handler)($call, $options);
+ *      }
+ * }
+ * ```
+ *
+ * Next, add the middleware to any class implementing `GapicClientTrait` by passing in a
+ * callable which returns the new middleware:
+ *
+ * ```
+ * $client = new ExampleGoogleApiServiceClient();
+ * $client->addMiddleware(function (MiddlewareInterface $handler) {
+ *     return new MyTestMiddleware($handler);
+ * });
+ * ```
+ */
+interface MiddlewareInterface
+{
+    /**
+     * Modify or observe the API call request and response.
+     * The returned value must include the result of the next MiddlewareInterface invocation in the
+     * chain.
+     *
+     * @param Call $call
+     * @param array $options
+     * @return PromiseInterface|ClientStream|ServerStream|BidiStream
+     */
+    public function __invoke(Call $call, array $options);
+}

--- a/src/Middleware/OperationsMiddleware.php
+++ b/src/Middleware/OperationsMiddleware.php
@@ -34,11 +34,12 @@ namespace Google\ApiCore\Middleware;
 use Google\ApiCore\Call;
 use Google\ApiCore\OperationResponse;
 use Google\Protobuf\Internal\Message;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
  * Middleware which wraps the response in an OperationResponse object.
  */
-class OperationsMiddleware
+class OperationsMiddleware implements MiddlewareInterface
 {
     /** @var callable */
     private $nextHandler;

--- a/src/Middleware/OptionsFilterMiddleware.php
+++ b/src/Middleware/OptionsFilterMiddleware.php
@@ -33,11 +33,12 @@ namespace Google\ApiCore\Middleware;
 
 use Google\ApiCore\ArrayTrait;
 use Google\ApiCore\Call;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
 * Middleware which filters the $options array.
 */
-class OptionsFilterMiddleware
+class OptionsFilterMiddleware implements MiddlewareInterface
 {
     use ArrayTrait;
 

--- a/src/Middleware/PagedMiddleware.php
+++ b/src/Middleware/PagedMiddleware.php
@@ -36,11 +36,12 @@ use Google\ApiCore\Page;
 use Google\ApiCore\PagedListResponse;
 use Google\ApiCore\PageStreamingDescriptor;
 use Google\Protobuf\Internal\Message;
+use GuzzleHttp\Promise\PromiseInterface;
 
 /**
 * Middleware which wraps the response in an PagedListResponses object.
 */
-class PagedMiddleware
+class PagedMiddleware implements MiddlewareInterface
 {
     /** @var callable */
     private $nextHandler;

--- a/src/Middleware/ResponseMetadataMiddleware.php
+++ b/src/Middleware/ResponseMetadataMiddleware.php
@@ -38,7 +38,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 /**
  * Middleware which transforms $response into [$response, $metadata]
  */
-class ResponseMetadataMiddleware
+class ResponseMetadataMiddleware implements MiddlewareInterface
 {
     /** @var callable */
     private $nextHandler;

--- a/src/Middleware/RetryMiddleware.php
+++ b/src/Middleware/RetryMiddleware.php
@@ -40,7 +40,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 /**
  * Middleware that adds retry functionality.
  */
-class RetryMiddleware
+class RetryMiddleware implements MiddlewareInterface
 {
     /** @var callable */
     private $nextHandler;


### PR DESCRIPTION
Implementation for Option 2 of [go/php-interceptors-and-middlewares](https://goto.google.com/php-interceptors-and-middlewares):

```php
$client->addMiddleware(function (MiddlewareInterface $handler) {
    return new class ($handler) implements MiddlewareInterface {
        public function __construct(private MiddlewareInterface $handler) {
        }

        /**
         * Modify or observe the API call request and response.
         * The returned value must include the result of the next MiddlewareInterface invocation in the
         * chain.
         *
         * @param Call $call
         * @param array $options
         * @return PromiseInterface|ClientStream|ServerStream|BidiStream
         */
        public function __invoke(Call $call, array $options) {
            // do middleware stuff (pre-request)
            $response = ($this->handler)($call, $options);
            // do middleware stuff (post-request)
            return $response;
        }
    };
});
```

