### PR TITLE
Revert "chore: remove unnecessary api endpoint check"

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -200,6 +200,15 @@ trait GapicClientTrait
             $options['apiEndpoint'] = $this->pluck('serviceAddress', $options, false);
         }
 
+        // If an API endpoint is set, ensure the "audience" does not conflict
+        // with the custom endpoint by setting "user defined" scopes.
+        if ($options['apiEndpoint'] != $defaultOptions['apiEndpoint']
+            && empty($options['credentialsConfig']['scopes'])
+            && !empty($options['credentialsConfig']['defaultScopes'])
+        ) {
+            $options['credentialsConfig']['scopes'] = $options['credentialsConfig']['defaultScopes'];
+        }
+
         if (extension_loaded('sysvshm')
                 && isset($options['gcpApiConfigPath'])
                 && file_exists($options['gcpApiConfigPath'])

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -1389,6 +1389,16 @@ class GapicClientTraitTest extends TestCase
         $defaultOptions = $client->call('buildClientOptions', [[]]);
         $this->assertArrayNotHasKey('scopes', $defaultOptions['credentialsConfig']);
 
+        // verify scopes are set when a custom api endpoint is used
+        $defaultOptions = $client->call('buildClientOptions', [[
+            'apiEndpoint' => 'www.someotherendpoint.com',
+        ]]);
+        $this->assertArrayHasKey('scopes', $defaultOptions['credentialsConfig']);
+        $this->assertEquals(
+            $client::$serviceScopes,
+            $defaultOptions['credentialsConfig']['scopes']
+        );
+
         // verify user-defined scopes override default scopes
         $defaultOptions = $client->call('buildClientOptions', [[
             'credentialsConfig' => ['scopes' => ['user-scope-1']],
@@ -1448,36 +1458,6 @@ class GapicClientTraitTest extends TestCase
 
         $client->call('startCall', ['method.name', 'decodeType', [
             'audience' => 'custom-audience',
-        ]]);
-    }
-
-    public function testDefaultAudienceWithCustomApiEndpoint()
-    {
-        $retrySettings = $this->prophesize(RetrySettings::class);
-        $credentialsWrapper = $this->prophesize(CredentialsWrapper::class)
-            ->reveal();
-        $transport = $this->prophesize(TransportInterface::class);
-        $transport
-            ->startUnaryCall(
-                Argument::any(),
-                [
-                    'audience' => 'https://service-address/',
-                    'headers' => [],
-                    'credentialsWrapper' => $credentialsWrapper,
-                ]
-            )
-            ->shouldBeCalledOnce();
-
-        $client = new GapicClientTraitDefaultScopeAndAudienceStub();
-        $client->set('credentialsWrapper', $credentialsWrapper);
-        $client->set('agentHeader', []);
-        $client->set(
-            'retrySettings',
-            ['method.name' => $retrySettings->reveal()]
-        );
-        $client->set('transport', $transport->reveal());
-        $client->call('startCall', ['method.name', 'decodeType', [
-            'apiEndpoint' => 'www.someotherendpoint.com',
         ]]);
     }
 


### PR DESCRIPTION
Reverts googleapis/gax-php#313

This seems a necessary piece of code as this was responsible for forwarding the default auth scopes of the clients using [GapicClientTrait](https://github.com/googleapis/gax-php/blob/main/src/GapicClientTrait.php).

We started receiving errors related to missing auth. More info at this [issue](https://github.com/googleapis/google-cloud-php/issues/6386).