### PR TITLE
Fix: creation of dynamic property $newClient is deprecated issue #481

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -81,6 +81,7 @@ trait GapicClientTrait
         Call::SERVER_STREAMING_CALL => 'startServerStreamingCall',
     ];
     private bool $isNewClient;
+    private bool $newClient;
 
     /**
      * Initiates an orderly shutdown in which preexisting calls continue but new


### PR DESCRIPTION
Fix to prevent the PHP 8.2 exception being thrown on  line 1077. 