### PR TITLE
fix: deprecation notice while GapicClientTrait->setClientOptions

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -81,6 +81,7 @@ trait GapicClientTrait
         Call::SERVER_STREAMING_CALL => 'startServerStreamingCall',
     ];
     private bool $isNewClient;
+    private $newClient;
 
     /**
      * Initiates an orderly shutdown in which preexisting calls continue but new

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -81,7 +81,6 @@ trait GapicClientTrait
         Call::SERVER_STREAMING_CALL => 'startServerStreamingCall',
     ];
     private bool $isNewClient;
-    private $newClient;
 
     /**
      * Initiates an orderly shutdown in which preexisting calls continue but new
@@ -1075,6 +1074,6 @@ trait GapicClientTrait
      */
     private function isNewClientSurface(): bool
     {
-        return $this->isNewClient ?? $this->newClient = substr(__CLASS__, -10) === 'BaseClient';
+        return $this->isNewClient ?? $this->isNewClient = substr(__CLASS__, -10) === 'BaseClient';
     }
 }


### PR DESCRIPTION
Fix for the following deprecation notice:
```
PHP Deprecated:  Creation of dynamic property Google\Cloud\PubSub\V1\PublisherClient::$newClient 
is deprecated in /Users/vishwarajanand/github/google-cloud-php/PubSub/vendor/google/gax/src/GapicClientTrait.php 
on line 1077
```