### PR TITLE
chore(docs): update token name

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,6 @@ jobs:
         - name: Deploy 🚀
           uses: JamesIves/github-pages-deploy-action@releases/v3
           with:
-            ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+            ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             BRANCH: gh-pages
             FOLDER: ghpages


### PR DESCRIPTION
The docs generation job is failing, and I believe this is because we are using  a non-existent `secrets.ACCESS_TOKEN` instead of the default `secrets.GITHUB_TOKEN`

see https://docs.github.com/en/actions/security-guides/automatic-token-authentication

I'm not sure what caused this to start failing - I may have removed the secret because I thought it was unused