### PR TITLE
fix: ensure credentialsFetcher is nullable

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -54,7 +54,7 @@ class CredentialsWrapper
     use ValidationTrait;
 
     /** @var FetchAuthTokenInterface $credentialsFetcher */
-    private FetchAuthTokenInterface $credentialsFetcher;
+    private ?FetchAuthTokenInterface $credentialsFetcher = null;
     /** @var callable $authHttpHandle */
     private $authHttpHandler;
 


### PR DESCRIPTION
Follow up to https://github.com/googleapis/gax-php/pull/452 - we need to make the `$credentialsFetcher` property of `CredentialsWrapper` nullable, otherwise tests in the monorepo will fail
