### PR TITLE
chore: gax test warnings

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  bootstrap="tests/bootstrap.php"
-  xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-  colors="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/ApiCore</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="unit">
       <directory>tests/Tests/Unit</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src/ApiCore</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -1745,6 +1745,8 @@ class GapicClientTraitTest extends TestCase
         };
         $middleware2 = function (MiddlewareInterface $handler) use (&$m2Called) {
             return new class ($handler, $m2Called) implements MiddlewareInterface {
+                private MiddlewareInterface $handler;
+                private bool $m2Called;
                 public function __construct(
                     MiddlewareInterface $handler,
                     bool &$m2Called

--- a/tests/Tests/Unit/GapicClientTraitTest.php
+++ b/tests/Tests/Unit/GapicClientTraitTest.php
@@ -1730,6 +1730,8 @@ class GapicClientTraitTest extends TestCase
         $m2Called = false;
         $middleware1 = function (MiddlewareInterface $handler) use (&$m1Called) {
             return new class ($handler, $m1Called) implements MiddlewareInterface {
+                private MiddlewareInterface $handler;
+                private bool $m1Called;
                 public function __construct(
                     MiddlewareInterface $handler,
                     bool &$m1Called

--- a/tests/Tests/Unit/Transport/GrpcTransportTest.php
+++ b/tests/Tests/Unit/Transport/GrpcTransportTest.php
@@ -583,6 +583,7 @@ class GrpcTransportTest extends TestCase
 class MockCallInvoker implements CallInvoker
 {
     private $called = false;
+    private $mockCall;
 
     public function __construct($mockCall)
     {


### PR DESCRIPTION
Fixing following warnings:
1. GrpcTransportTest
```
PHP Deprecated: Creation of dynamic property Google\ApiCore\Tests\Unit\Transport\MockCallInvoker::$mockCall is deprecated in /usr/local/google/home/vishwarajanand/github/gax-php/tests/Tests/Unit/Transport/GrpcTransportTest.php on line 589
```

2. GapicClientTraitTest
```PHP Deprecated:  Creation of dynamic property Google\ApiCore\Middleware\MiddlewareInterface@anonymous::$handler is deprecated in /usr/local/google/home/vishwarajanand/github/gax-php/tests/Tests/Unit/GapicClientTraitTest.php on line 1760
PHP Deprecated:  Creation of dynamic property Google\ApiCore\Middleware\MiddlewareInterface@anonymous::$m2Called is deprecated in /usr/local/google/home/vishwarajanand/github/gax-php/tests/Tests/Unit/GapicClientTraitTest.php on line 1761
PHP Deprecated:  Creation of dynamic property Google\ApiCore\Middleware\MiddlewareInterface@anonymous::$handler is deprecated in /usr/local/google/home/vishwarajanand/github/gax-php/tests/Tests/Unit/GapicClientTraitTest.php on line 1745
PHP Deprecated:  Creation of dynamic property Google\ApiCore\Middleware\MiddlewareInterface@anonymous::$m1Called is deprecated in /usr/local/google/home/vishwarajanand/github/gax-php/tests/Tests/Unit/GapicClientTraitTest.php on line 1746
```

3. phpunit config:
```Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```