### PR TITLE
fix: widen google/longrunning version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/promises": "^1.4||^2.0",
         "guzzlehttp/psr7": "^2.0",
         "google/common-protos": "^3.0||^4.0",
-        "google/longrunning": "^0.2"
+        "google/longrunning": "~0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
we need to use `~2.0` instead of `^2.0`  for `google/longrunning` in order to allow version `0.3` (and future `0.x` releases). This is because, as the library is part of `google/cloud`, when a new feature release rolls out, it breaks the build because it cannot find a suitable version (see https://github.com/googleapis/google-cloud-php/pull/6868)