### PR TITLE
fix: correct exception type for Guzzle promise

### DIFF
--- a/src/Transport/RestTransport.php
+++ b/src/Transport/RestTransport.php
@@ -160,7 +160,7 @@ class RestTransport implements TransportInterface
 
                 return $return;
             },
-            function (\Exception $ex) {
+            function (\Throwable $ex) {
                 if ($ex instanceof RequestException && $ex->hasResponse()) {
                     throw ApiException::createFromRequestException($ex);
                 }


### PR DESCRIPTION
fixes https://github.com/googleapis/gax-php/issues/310

Properly accepts all `Throwable` types in Guzzle promises

See https://github.com/guzzle/promises/blob/2.0/src/RejectedPromise.php#L52