### PR TITLE
feat: update ArrayTrait to be consistent with Core

### DIFF
--- a/src/ArrayTrait.php
+++ b/src/ArrayTrait.php
@@ -127,4 +127,30 @@ trait ArrayTrait
             array_flip($keys)
         );
     }
+
+    /**
+     * A method, similar to PHP's `array_merge_recursive`, with two differences.
+     *
+     * 1. Keys in $array2 take precedence over keys in $array1.
+     * 2. Non-array keys found in both inputs are not transformed into an array
+     *    and appended. Rather, the value in $array2 is used.
+     *
+     * @param array $array1
+     * @param array $array2
+     * @return array
+     */
+    private function arrayMergeRecursive(array $array1, array $array2)
+    {
+        foreach ($array2 as $key => $value) {
+            if (array_key_exists($key, $array1) && is_array($array1[$key]) && is_array($value)) {
+                $array1[$key] = ($this->isAssoc($array1[$key]) && $this->isAssoc($value))
+                    ? $this->arrayMergeRecursive($array1[$key], $value)
+                    : array_merge($array1[$key], $value);
+            } else {
+                $array1[$key] = $value;
+            }
+        }
+
+        return $array1;
+    }
 }

--- a/tests/Tests/Unit/ArrayTraitTest.php
+++ b/tests/Tests/Unit/ArrayTraitTest.php
@@ -153,6 +153,34 @@ class ArrayTraitTest extends TestCase
             ]
         ];
     }
+
+    public function testArrayMergeRecursive()
+    {
+        $array1 = [
+            'a' => [
+                'b' => 'c'
+            ],
+            'e' => 'f'
+        ];
+
+        $array2 = [
+            'a' => [
+                'b' => 'd'
+            ],
+            'g' => 'h'
+        ];
+
+        $expected = [
+            'a' => [
+                'b' => 'd'
+            ],
+            'e' => 'f',
+            'g' => 'h'
+        ];
+
+        $res = $this->implementation->arrayMergeRecursive($array1, $array2);
+        $this->assertEquals($expected, $res);
+    }
 }
 
 class ArrayTraitStub
@@ -163,5 +191,6 @@ class ArrayTraitStub
         pluck as public;
         pluckArray as public;
         subsetArray as public;
+        arrayMergeRecursive as public;
     }
 }


### PR DESCRIPTION
The purpose of this PR is to make ArrayTrait in ApiCore consistent with the ArrayTrait in Core.
With this we can replace the references of Core/ArrayTrait with ApiCore/ArrayTrait in v2 handwritten clients.