### PR TITLE
fix: universe domain check for grpc transport

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -272,7 +272,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
     /**
      * Verify that the expected universe domain matches the universe domain from the credentials.
      */
-    private function checkUniverseDomain()
+    public function checkUniverseDomain()
     {
         if (false === $this->hasCheckedUniverse) {
             $credentialsUniverse = $this->credentialsFetcher instanceof GetUniverseDomainInterface

--- a/src/Transport/GrpcTransport.php
+++ b/src/Transport/GrpcTransport.php
@@ -159,6 +159,8 @@ class GrpcTransport extends BaseStub implements TransportInterface
      */
     public function startBidiStreamingCall(Call $call, array $options)
     {
+        $this->verifyUniverseDomain($options);
+
         return new BidiStream(
             $this->_bidiRequest(
                 '/' . $call->getMethod(),
@@ -175,6 +177,9 @@ class GrpcTransport extends BaseStub implements TransportInterface
      */
     public function startClientStreamingCall(Call $call, array $options)
     {
+
+        $this->verifyUniverseDomain($options);
+
         return new ClientStream(
             $this->_clientStreamRequest(
                 '/' . $call->getMethod(),
@@ -191,6 +196,8 @@ class GrpcTransport extends BaseStub implements TransportInterface
      */
     public function startServerStreamingCall(Call $call, array $options)
     {
+        $this->verifyUniverseDomain($options);
+
         $message = $call->getMessage();
 
         if (!$message) {
@@ -216,6 +223,8 @@ class GrpcTransport extends BaseStub implements TransportInterface
      */
     public function startUnaryCall(Call $call, array $options)
     {
+        $this->verifyUniverseDomain($options);
+
         $unaryCall = $this->_simpleRequest(
             '/' . $call->getMethod(),
             $call->getMessage(),
@@ -243,6 +252,13 @@ class GrpcTransport extends BaseStub implements TransportInterface
         );
 
         return $promise;
+    }
+
+    private function verifyUniverseDomain(array $options)
+    {
+        if (isset($options['credentialsWrapper'])) {
+            $options['credentialsWrapper']->checkUniverseDomain();
+        }
     }
 
     private function getCallOptions(array $options)

--- a/tests/Tests/Unit/Transport/GrpcTransportTest.php
+++ b/tests/Tests/Unit/Transport/GrpcTransportTest.php
@@ -387,6 +387,8 @@ class GrpcTransportTest extends TestCase
         $call->getDecodeType()->shouldBeCalled();
 
         $credentialsWrapper = $this->prophesize(CredentialsWrapper::class);
+        $credentialsWrapper->checkUniverseDomain()
+            ->shouldBeCalledOnce();
         $credentialsWrapper->getAuthorizationHeaderCallback('an-audience')
             ->shouldBeCalledOnce();
         $hostname = '';


### PR DESCRIPTION
fixes #533

Checks the universe domain _before_ invoking the grpc libraries. This ensures that a segfault doesn't happen when the universe domain is invalid. 

1. Is this the best way to do this?
2. Should this be addressed in grpc core itself?