### PR TITLE
feat: Make the default authHttpHandler in CredentialsWrapper null

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -81,7 +81,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
         string $universeDomain = GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN
     ) {
         $this->credentialsFetcher = $credentialsFetcher;
-        $this->authHttpHandler = $authHttpHandler ?: self::buildHttpHandlerFactory();
+        $this->authHttpHandler = $authHttpHandler;
         if (empty($universeDomain)) {
             throw new ValidationException('The universe domain cannot be empty');
         }
@@ -141,7 +141,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
         ];
 
         $keyFile = $args['keyFile'];
-        $authHttpHandler = $args['authHttpHandler'] ?: self::buildHttpHandlerFactory();
+        $authHttpHandler = $args['authHttpHandler'];
 
         if (is_null($keyFile)) {
             $loader = self::buildApplicationDefaultCredentials(

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -290,19 +290,6 @@ class CredentialsWrapper implements ProjectIdProviderInterface
     }
 
     /**
-     * @return Guzzle6HttpHandler|Guzzle7HttpHandler
-     * @throws ValidationException
-     */
-    private static function buildHttpHandlerFactory()
-    {
-        try {
-            return HttpHandlerFactory::build();
-        } catch (Exception $ex) {
-            throw new ValidationException("Failed to build HttpHandler", $ex->getCode(), $ex);
-        }
-    }
-
-    /**
      * @param array $scopes
      * @param callable $authHttpHandler
      * @param array $authCacheOptions

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -141,12 +141,11 @@ class CredentialsWrapper implements ProjectIdProviderInterface
         ];
 
         $keyFile = $args['keyFile'];
-        $authHttpHandler = $args['authHttpHandler'];
 
         if (is_null($keyFile)) {
             $loader = self::buildApplicationDefaultCredentials(
                 $args['scopes'],
-                $authHttpHandler,
+                $args['authHttpHandler'],
                 $args['authCacheOptions'],
                 $args['authCache'],
                 $args['quotaProject'],
@@ -189,7 +188,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
             );
         }
 
-        return new CredentialsWrapper($loader, $authHttpHandler, $universeDomain);
+        return new CredentialsWrapper($loader, $args['authHttpHandler'], $universeDomain);
     }
 
     /**

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -83,7 +83,7 @@ class CredentialsWrapperTest extends TestCase
         $appDefaultCreds = getenv('GOOGLE_APPLICATION_CREDENTIALS');
         putenv('GOOGLE_APPLICATION_CREDENTIALS=' . __DIR__ . '/testdata/json-key-file.json');
         $scopes = ['myscope'];
-        $defaultAuthHttpHandler = HttpHandlerFactory::build();
+        $defaultAuthHttpHandler = null;
         $authHttpHandler = HttpHandlerFactory::build();
         $asyncAuthHttpHandler = function ($request, $options) use ($authHttpHandler) {
             return $authHttpHandler->async($request, $options)->wait();
@@ -96,11 +96,11 @@ class CredentialsWrapperTest extends TestCase
         $testData = [
             [
                 [],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $defaultAuthHttpHandler, null, $defaultAuthCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache), $defaultAuthHttpHandler),
             ],
             [
                 ['scopes' => $scopes],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials($scopes, $defaultAuthHttpHandler, null, $defaultAuthCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials($scopes, $authHttpHandler, null, $defaultAuthCache), $defaultAuthHttpHandler),
             ],
             [
                 ['scopes' => $scopes, 'authHttpHandler' => $asyncAuthHttpHandler],
@@ -108,19 +108,19 @@ class CredentialsWrapperTest extends TestCase
             ],
             [
                 ['enableCaching' => false],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $defaultAuthHttpHandler, null, null), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, null), $defaultAuthHttpHandler),
             ],
             [
                 ['authCacheOptions' => $authCacheOptions],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $defaultAuthHttpHandler, $authCacheOptions, $defaultAuthCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, $authCacheOptions, $defaultAuthCache), $defaultAuthHttpHandler),
             ],
             [
                 ['authCache' => $authCache],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $defaultAuthHttpHandler, null, $authCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $authCache), $defaultAuthHttpHandler),
             ],
             [
                 ['quotaProject' => $quotaProject],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $defaultAuthHttpHandler, null, $defaultAuthCache, $quotaProject), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache, $quotaProject), $defaultAuthHttpHandler),
             ],
         ];
 

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -83,7 +83,6 @@ class CredentialsWrapperTest extends TestCase
         $appDefaultCreds = getenv('GOOGLE_APPLICATION_CREDENTIALS');
         putenv('GOOGLE_APPLICATION_CREDENTIALS=' . __DIR__ . '/testdata/json-key-file.json');
         $scopes = ['myscope'];
-        $defaultAuthHttpHandler = null;
         $authHttpHandler = HttpHandlerFactory::build();
         $asyncAuthHttpHandler = function ($request, $options) use ($authHttpHandler) {
             return $authHttpHandler->async($request, $options)->wait();
@@ -96,11 +95,11 @@ class CredentialsWrapperTest extends TestCase
         $testData = [
             [
                 [],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache)),
             ],
             [
                 ['scopes' => $scopes],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials($scopes, $authHttpHandler, null, $defaultAuthCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials($scopes, $authHttpHandler, null, $defaultAuthCache)),
             ],
             [
                 ['scopes' => $scopes, 'authHttpHandler' => $asyncAuthHttpHandler],
@@ -108,19 +107,19 @@ class CredentialsWrapperTest extends TestCase
             ],
             [
                 ['enableCaching' => false],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, null), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, null)),
             ],
             [
                 ['authCacheOptions' => $authCacheOptions],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, $authCacheOptions, $defaultAuthCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, $authCacheOptions, $defaultAuthCache)),
             ],
             [
                 ['authCache' => $authCache],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $authCache), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $authCache)),
             ],
             [
                 ['quotaProject' => $quotaProject],
-                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache, $quotaProject), $defaultAuthHttpHandler),
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache, $quotaProject)),
             ],
         ];
 

--- a/tests/Tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Tests/Unit/CredentialsWrapperTest.php
@@ -557,4 +557,13 @@ class CredentialsWrapperTest extends TestCase
         $credentialsWrapper = new CredentialsWrapper($cache);
         $this->assertEquals('my-project-id', $credentialsWrapper->getProjectId());
     }
+
+    public function testSerializeCredentialsWrapper()
+    {
+        $credentialsWrapper = CredentialsWrapper::build([
+            'keyFile' => __DIR__ . '/testdata/json-key-file.json',
+        ]);
+        $serialized = serialize($credentialsWrapper);
+        $this->assertIsString($serialized);
+    }
 }


### PR DESCRIPTION
Currently the [v2 samples for Pubsub](https://github.com/GoogleCloudPlatform/php-docs-samples/pull/1967) are failing due to an internal attempt to `serialize` the `PubSubClient` in the `BatchPublisher`.
This is because the default `authHttpHandler` contains a closure. With this PR we make the default handler as `null`.