### PR TITLE
fix: Pass authHttpHandler to credentialsFetcher::updateMetadata

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -250,7 +250,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
 
                 // Call updateMetadata to take advantage of self-signed JWTs
                 if ($this->credentialsFetcher instanceof UpdateMetadataInterface) {
-                    return $this->credentialsFetcher->updateMetadata([], $audience);
+                    return $this->credentialsFetcher->updateMetadata([], $audience, $this->authHttpHandler);
                 }
 
                 // In case a custom fetcher is provided (unlikely) which doesn't


### PR DESCRIPTION
This PR fixes #548 by passing `$this->authHttpHandler` to `$this->credentialsFetcher->updateMetadata()`.
See #548 for details.