### PR TITLE
chore: Add caching and micro optimizations in Serializer.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
                     extensions: "protobuf,grpc"
                     tools: "pecl"
                   - php: "8.0"
-                    composerflags: " --prefer-lowest"
+                    composerflags: "--prefer-lowest"
         name: "PHP ${{ matrix.php }} Unit Test ${{ matrix.extensions }}${{ matrix.composerflags }}"
         steps:
             - uses: actions/checkout@v4

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -465,7 +465,9 @@ class Serializer
     public static function toSnakeCase(string $key)
     {
         if (!isset(self::$snakeCaseMap[$key])) {
-            self::$snakeCaseMap[$key] = strtolower(preg_replace(['/([a-z\d])([A-Z])/', '/([^_])([A-Z][a-z])/'], '$1_$2', $key));
+            self::$snakeCaseMap[$key] = strtolower(
+                preg_replace(['/([a-z\d])([A-Z])/', '/([^_])([A-Z][a-z])/'], '$1_$2', $key)
+            );
         }
         return self::$snakeCaseMap[$key];
     }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -438,7 +438,7 @@ class Serializer
      */
     public static function getGetter(string $name)
     {
-        if (! isset(self::$getterMap[$name])) {
+        if (!isset(self::$getterMap[$name])) {
             self::$getterMap[$name] = 'get' . ucfirst(self::toCamelCase($name));
         }
         return self::$getterMap[$name];
@@ -450,7 +450,7 @@ class Serializer
      */
     public static function getSetter(string $name)
     {
-        if (! isset(self::$setterMap[$name])) {
+        if (!isset(self::$setterMap[$name])) {
             self::$setterMap[$name] = 'set' . ucfirst(self::toCamelCase($name));
         }
         return self::$setterMap[$name];
@@ -464,7 +464,7 @@ class Serializer
      */
     public static function toSnakeCase(string $key)
     {
-        if (! isset(self::$snakeCaseMap[$key])) {
+        if (!isset(self::$snakeCaseMap[$key])) {
             self::$snakeCaseMap[$key] = strtolower(preg_replace(['/([a-z\d])([A-Z])/', '/([^_])([A-Z][a-z])/'], '$1_$2', $key));
         }
         return self::$snakeCaseMap[$key];
@@ -478,7 +478,7 @@ class Serializer
      */
     public static function toCamelCase(string $key)
     {
-        if (! isset(self::$camelCaseMap[$key])) {
+        if (!isset(self::$camelCaseMap[$key])) {
             self::$camelCaseMap[$key] = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
         }
         return self::$camelCaseMap[$key];

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -47,6 +47,11 @@ class Serializer
     const MAP_VALUE_FIELD_NAME = 'value';
 
     private static $phpArraySerializer;
+    // Caches for different helper functions
+    private static array $getterMap = [];
+    private static array $setterMap = [];
+    private static array $snakeCaseMap = [];
+    private static array $camelCaseMap = [];
 
     private static $metadataKnownTypes = [
         'google.rpc.retryinfo-bin' => \Google\Rpc\RetryInfo::class,
@@ -294,9 +299,10 @@ class Serializer
     {
         $data = [];
 
-        $fieldCount = $messageType->getFieldCount();
-        for ($i = 0; $i < $fieldCount; $i++) {
-            $field = $messageType->getField($i);
+        // Call the getDescriptorMaps outside of the loop to save processing.
+        // Use the same set of fields to loop over, instead of using field count.
+        list($fields, $fieldsToOneof) = $this->getDescriptorMaps($messageType);
+        foreach ($fields as $field) {
             $key = $field->getName();
             $getter = $this->getGetter($key);
             $v = $message->$getter();
@@ -306,7 +312,6 @@ class Serializer
             }
 
             // Check and skip unset fields inside oneofs
-            list($_, $fieldsToOneof) = $this->getDescriptorMaps($messageType);
             if (isset($fieldsToOneof[$key])) {
                 $oneofName = $fieldsToOneof[$key];
                 $oneofGetter =  $this->getGetter($oneofName);
@@ -433,7 +438,10 @@ class Serializer
      */
     public static function getGetter(string $name)
     {
-        return 'get' . ucfirst(self::toCamelCase($name));
+        if (! isset(self::$getterMap[$name])) {
+            self::$getterMap[$name] = 'get' . ucfirst(self::toCamelCase($name));
+        }
+        return self::$getterMap[$name];
     }
 
     /**
@@ -442,7 +450,10 @@ class Serializer
      */
     public static function getSetter(string $name)
     {
-        return 'set' . ucfirst(self::toCamelCase($name));
+        if (! isset(self::$setterMap[$name])) {
+            self::$setterMap[$name] = 'set' . ucfirst(self::toCamelCase($name));
+        }
+        return self::$setterMap[$name];
     }
 
     /**
@@ -453,7 +464,10 @@ class Serializer
      */
     public static function toSnakeCase(string $key)
     {
-        return strtolower(preg_replace(['/([a-z\d])([A-Z])/', '/([^_])([A-Z][a-z])/'], '$1_$2', $key));
+        if (! isset(self::$snakeCaseMap[$key])) {
+            self::$snakeCaseMap[$key] = strtolower(preg_replace(['/([a-z\d])([A-Z])/', '/([^_])([A-Z][a-z])/'], '$1_$2', $key));
+        }
+        return self::$snakeCaseMap[$key];
     }
 
     /**
@@ -464,7 +478,10 @@ class Serializer
      */
     public static function toCamelCase(string $key)
     {
-        return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
+        if (! isset(self::$camelCaseMap[$key])) {
+            self::$camelCaseMap[$key] = lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
+        }
+        return self::$camelCaseMap[$key];
     }
 
     private static function hasBinaryHeaderSuffix(string $key)


### PR DESCRIPTION
The 2 major changes here are:

### 1. Add some caching for `getGetter`, `getSetter`, `toSnakeCase` and `toCamelCase` methods.
#### Intuition:
For a simple script that calls `Select * From <table> LIMIT 100` where the table has 23 columns, the `getGetter` and `toCamelCase` were being called close to 500 times. Even though the operation is simple, but there is string manipulation and depends on the names that are used frequently. So, I simply added some caching for these methods.
### 2. Inside the `encodeMessageImpl` method, bring the call to `getDescriptorMaps` outside the loop.
#### Intuition:
The `getDescriptorMaps` depends on the `$messageType` which stays same inside the `for loop`. Moreover, the first argument returned, is actually a list of fields. So, instead of depending on the `$fieldsCount`, we can use this list to loop over the `$fields`.

### Effect
I ran a simple script that runs the same query as above 5 times, both with and without the protobuf extension enabled and I could see a good improvement for both the cases.

#### Protobuf extension not enabled

**Current(w/o this fix):**
Running query select * from Accounts LIMIT 100
Time taken: 1.73 s

Running query select * from Accounts LIMIT 100
Time taken: 1.51 s

Running query select * from Accounts LIMIT 100
Time taken: 1.63 s

Running query select * from Accounts LIMIT 100
Time taken: 1.51 s

Running query select * from Accounts LIMIT 100
Time taken: 1.49 s

Completed in 7.86 s

**With the fix:**
Running query select * from Accounts LIMIT 100
Time taken: 1.34 s

Running query select * from Accounts LIMIT 100
Time taken: 1.19 s

Running query select * from Accounts LIMIT 100
Time taken: 1.19 s

Running query select * from Accounts LIMIT 100
Time taken: 1.22 s

Running query select * from Accounts LIMIT 100
Time taken: 1.19 s

Completed in 6.14 s

#### Protobuf extension enabled
**Current(w/o this fix):**
Running query select * from Accounts LIMIT 100
Time taken: 575.849987 ms

Running query select * from Accounts LIMIT 100
Time taken: 521.261092 ms

Running query select * from Accounts LIMIT 100
Time taken: 449.397046 ms

Running query select * from Accounts LIMIT 100
Time taken: 449.931335 ms

Running query select * from Accounts LIMIT 100
Time taken: 461.896432 ms

Completed in 2.49 s

**With the fix:**

Running query select * from Accounts LIMIT 100
Time taken: 425.538723 ms

Running query select * from Accounts LIMIT 100
Time taken: 308.273615 ms

Running query select * from Accounts LIMIT 100
Time taken: 322.510244 ms

Running query select * from Accounts LIMIT 100
Time taken: 304.450003 ms

Running query select * from Accounts LIMIT 100
Time taken: 517.975938 ms

Completed in 1.88 s

Clearly, we see a good improvement in both the cases.