### PR TITLE
chore(tests): add phpstan as a dev dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,4 @@ jobs:
           php-version: '8.2'
       - name: Run Script
         run: |
-          composer install
-          composer global require phpstan/phpstan
-          ~/.composer/vendor/bin/phpstan analyse
+          vendor/bin/phpstan analyse

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+      - name: Install Dependencies
+        uses: nick-invision/retry@v3
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: composer install
       - name: Run Script
         run: |
           vendor/bin/phpstan analyse

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
+          php-version: '8.2'
       - name: Install Dependencies
         uses: nick-invision/retry@v3
         with:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.6",
         "squizlabs/php_codesniffer": "3.*",
-        "phpspec/prophecy-phpunit": "^2.1"
+        "phpspec/prophecy-phpunit": "^2.1",
+        "phpstan/phpstan": "^1.10"
     },
     "conflict": {
         "ext-protobuf": "<3.7.0"


### PR DESCRIPTION
For those folks that would like to run phpstan before they open a PR I moved phpstan to lib dev dependencies as it's not creating any conflicts. 