### PR TITLE
fix: failing tests by moving GOOGLE_APPLICATION_CREDENTIALS to phpunit.xml.dist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,6 @@ jobs:
                 max_attempts: 3
                 command: composer update ${{ matrix.composerflags }}
             - name: Run script
-              env:
-                GOOGLE_APPLICATION_CREDENTIALS: ${{github.workspace}}/tests/Tests/Unit/testdata/json-key-file.json
               run: vendor/bin/phpunit
 
     style:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ be found for Mac or Windows.
 3.  Run tests.
 
     ```sh
-    > vendor/bin/phpunit --bootstrap tests/bootstrap.php tests
+    > vendor/bin/phpunit
     ```
 
 4.  Updating dependencies after changing `composer.json`:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true">
+  <php>
+    <env name="GOOGLE_APPLICATION_CREDENTIALS" value="tests/Tests/Unit/testdata/json-key-file.json"/>
+  </php>
   <coverage>
     <include>
       <directory suffix=".php">src/ApiCore</directory>


### PR DESCRIPTION
The solution mentioned [here](https://github.com/googleapis/gax-php/pull/555#discussion_r1575000105) is already implemented, when I first time tried to execute those tests they were failing not due to missing extensions, but missing env var. 
I moved that env var to phpunit.xml.dist so now the whole testsuite should pass regardless if the extensions are installed or not. 