### PR TITLE
draft: Support operations for compute v2 with Reflection

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -629,7 +629,7 @@ trait GapicClientTrait
                 'X-Goog-User-Project' => [$quotaProject]
             ];
         }
-        
+
         if (isset($this->apiVersion)) {
             $fixedHeaders += [
                 'X-Goog-Api-Version' => [$this->apiVersion]

--- a/src/OperationResponse.php
+++ b/src/OperationResponse.php
@@ -269,10 +269,7 @@ class OperationResponse
         if ($this->operationsClient instanceof OperationsClient) {
             $requestClass = GetOperationRequest::class;
         } elseif ($this->isNewSurfaceOperationsClient()) {
-            $requestClass = (new \ReflectionMethod(
-                $this->operationsClient,
-                $this->getOperationMethod)
-            )->getParameters()[0]->getType()->getName();
+            $requestClass = $this->getRequestClass($this->getOperationMethod);
         }
 
         $this->lastProtoResponse = $this->operationsCall($this->getOperationMethod, $requestClass);
@@ -403,10 +400,7 @@ class OperationResponse
         if ($this->operationsClient instanceof OperationsClient) {
             $requestClass = CancelOperationRequest::class;
         } elseif ($this->isNewSurfaceOperationsClient()) {
-            $requestClass = (new \ReflectionMethod(
-                $this->operationsClient,
-                $this->cancelOperationMethod)
-            )->getParameters()[0]->getType()->getName();
+            $requestClass = $this->getRequestClass($this->cancelOperationMethod);
         }
 
         $this->operationsCall($this->cancelOperationMethod, $requestClass);
@@ -433,10 +427,7 @@ class OperationResponse
         if ($this->operationsClient instanceof OperationsClient) {
             $requestClass = DeleteOperationRequest::class;
         } elseif ($this->isNewSurfaceOperationsClient()) {
-            $requestClass = (new \ReflectionMethod(
-                $this->operationsClient,
-                $this->deleteOperationMethod)
-            )->getParameters()[0]->getType()->getName();
+            $requestClass = $this->getRequestClass($this->deleteOperationMethod);
         }
 
         $this->operationsCall($this->deleteOperationMethod, $requestClass);
@@ -534,5 +525,17 @@ class OperationResponse
     {
         return !$this->operationsClient instanceof LegacyOperationsClient
             && false !== strpos(get_class($this->operationsClient), '\\Client\\');
+    }
+
+    private function getRequestClass(string $method): string
+    {
+        $refl = new \ReflectionMethod($this->operationsClient, $method);
+        $type = $refl->getParameters()[0]->getType();
+
+        if (!$type instanceof \ReflectionNamedType) {
+            throw new \RuntimeException('Could not determine request class');
+        }
+
+        return $type->getName();
     }
 }

--- a/tests/Tests/Unit/OperationResponseTest.php
+++ b/tests/Tests/Unit/OperationResponseTest.php
@@ -274,7 +274,7 @@ class OperationResponseTest extends TestCase
                 $phpunit->assertEquals('test-123', $request->name);
                 $phpunit->assertEquals('arg2', $request->arg2);
                 $phpunit->assertEquals('arg3', $request->arg3);
-                return $phpunit->prophesize(Operation::class)->reveal();
+                return new \stdClass;
             });
         $operationClient->cancelNewSurfaceOperation(Argument::type(Client\CancelOperationRequest::class))
             ->shouldBeCalledOnce()

--- a/tests/Tests/Unit/testdata/src/CustomOperationClient.php
+++ b/tests/Tests/Unit/testdata/src/CustomOperationClient.php
@@ -1,0 +1,52 @@
+<?php
+
+// "Client" in the namespace tells OperationResponse that this is a new surface client
+namespace Google\ApiCore\Tests\Unit\Client;
+
+class NewSurfaceCustomOperationClient
+{
+    public function getNewSurfaceOperation(GetOperationRequest $request, array $callOptions = [])
+    {
+
+    }
+
+    public function cancelNewSurfaceOperation(CancelOperationRequest $request, array $callOptions = [])
+    {
+
+    }
+
+    public function deleteNewSurfaceOperation(DeleteOperationRequest $request, array $callOptions = [])
+    {
+
+    }
+}
+
+abstract class BaseOperationRequest
+{
+    public string $name;
+    public string $arg2;
+    public string $arg3;
+
+    public static function build(string $name, string $arg2, string $arg3): static
+    {
+        $request = new static();
+        $request->name = $name;
+        $request->arg2 = $arg2;
+        $request->arg3 = $arg3;
+
+        return $request;
+    }
+}
+
+class GetOperationRequest extends BaseOperationRequest
+{
+}
+
+class CancelOperationRequest extends BaseOperationRequest
+{
+}
+
+class DeleteOperationRequest extends BaseOperationRequest
+{
+}
+


### PR DESCRIPTION
Alternative implementation to #569 which uses `ReflectionMethod` instead of `Request` class configuration

**Pros**

 - does not require a change to the existing longRunning descriptors
 - fixing LRO for Compute does not require regenerating and re-releasing the compute client

**Cons**

 - Uses `ReflectionMethod` to determine first argument Request class

**Alternatives Considered**
We could add the options getRequestClass, cancelRequestClass, and deleteRequestClass to the descriptors via gapic-generator-php, which would be more efficient (no calls to ReflectionMethod) and better. See #569  and https://github.com/googleapis/gapic-generator-php/pull/712