### PR TITLE
Add `InsecureRequestBuilder` for emulator

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -218,6 +218,8 @@ trait GapicClientTrait
      */
     private function setClientOptions(array $options)
     {
+        $hasEmulator = $options['hasEmulator'] ?? false;
+
         // serviceAddress is now deprecated and acts as an alias for apiEndpoint
         if (isset($options['serviceAddress'])) {
             $options['apiEndpoint'] = $this->pluck('serviceAddress', $options, false);
@@ -300,7 +302,8 @@ trait GapicClientTrait
                 $options['apiEndpoint'],
                 $transport,
                 $options['transportConfig'],
-                $options['clientCertSource']
+                $options['clientCertSource'],
+                $hasEmulator
             );
     }
 
@@ -309,6 +312,7 @@ trait GapicClientTrait
      * @param string $transport
      * @param TransportOptions|array $transportConfig
      * @param callable $clientCertSource
+     * @param bool $hasEmulator
      * @return TransportInterface
      * @throws ValidationException
      */
@@ -316,7 +320,8 @@ trait GapicClientTrait
         string $apiEndpoint,
         $transport,
         $transportConfig,
-        callable $clientCertSource = null
+        callable $clientCertSource = null,
+        bool $hasEmulator = false
     ) {
         if (!is_string($transport)) {
             throw new ValidationException(
@@ -359,6 +364,8 @@ trait GapicClientTrait
                     );
                 }
                 $restConfigPath = $configForSpecifiedTransport['restClientConfigPath'];
+                $configForSpecifiedTransport['hasEmulator'] = $hasEmulator;
+
                 return RestTransport::build($apiEndpoint, $restConfigPath, $configForSpecifiedTransport);
             default:
                 throw new ValidationException(

--- a/src/InsecureRequestBuilder.php
+++ b/src/InsecureRequestBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Google\ApiCore;
+
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * @internal
+ */
+class InsecureRequestBuilder extends RequestBuilder
+{
+    /**
+     * @param string $baseUri
+     * @param string $restConfigPath
+     * @throws ValidationException
+     */
+    public function __construct(string $baseUri, string $restConfigPath)
+    {
+        parent::__construct($baseUri, $restConfigPath);
+    }
+
+    /**
+     * @param string $path
+     * @param array $queryParams
+     * @return UriInterface
+     */
+    protected function buildUri(string $path, array $queryParams)
+    {
+        $uri = Utils::uriFor(
+            sprintf(
+                'http://%s%s',
+                $this->baseUri,
+                $path
+            )
+        );
+        if ($queryParams) {
+            $uri = $this->buildUriWithQuery(
+                $uri,
+                $queryParams
+            );
+        }
+        return $uri;
+    }
+}

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -50,7 +50,7 @@ class RequestBuilder
     use UriTrait;
     use ValidationTrait;
 
-    private $baseUri;
+    protected $baseUri;
     private $restConfig;
 
     /**
@@ -270,7 +270,7 @@ class RequestBuilder
      * @param array $queryParams
      * @return UriInterface
      */
-    private function buildUri(string $path, array $queryParams)
+    protected function buildUri(string $path, array $queryParams)
     {
         $uri = Utils::uriFor(
             sprintf(

--- a/src/Transport/RestTransport.php
+++ b/src/Transport/RestTransport.php
@@ -33,6 +33,7 @@ namespace Google\ApiCore\Transport;
 
 use Google\ApiCore\ApiException;
 use Google\ApiCore\Call;
+use Google\ApiCore\InsecureRequestBuilder;
 use Google\ApiCore\RequestBuilder;
 use Google\ApiCore\ServerStream;
 use Google\ApiCore\ServiceAddressTrait;
@@ -97,7 +98,7 @@ class RestTransport implements TransportInterface
         ];
         list($baseUri, $port) = self::normalizeServiceAddress($apiEndpoint);
         $requestBuilder = $config['hasEmulator']
-            ? new InsecureRequestbuilder("$baseUri:$port", $restConfigPath)
+            ? new InsecureRequestBuilder("$baseUri:$port", $restConfigPath)
             : new RequestBuilder("$baseUri:$port", $restConfigPath);
         $httpHandler = $config['httpHandler'] ?: self::buildHttpHandlerAsync();
         $transport = new RestTransport($requestBuilder, $httpHandler);

--- a/src/Transport/RestTransport.php
+++ b/src/Transport/RestTransport.php
@@ -83,6 +83,7 @@ class RestTransport implements TransportInterface
      *
      *    @type callable $httpHandler A handler used to deliver PSR-7 requests.
      *    @type callable $clientCertSource A callable which returns the client cert as a string.
+     *    @type bool $hasEmulator True if the emulator is enabled.
      * }
      * @return RestTransport
      * @throws ValidationException
@@ -92,9 +93,12 @@ class RestTransport implements TransportInterface
         $config += [
             'httpHandler'  => null,
             'clientCertSource' => null,
+            'hasEmulator' => false,
         ];
         list($baseUri, $port) = self::normalizeServiceAddress($apiEndpoint);
-        $requestBuilder = new RequestBuilder("$baseUri:$port", $restConfigPath);
+        $requestBuilder = $config['hasEmulator']
+            ? new InsecureRequestbuilder("$baseUri:$port", $restConfigPath)
+            : new RequestBuilder("$baseUri:$port", $restConfigPath);
         $httpHandler = $config['httpHandler'] ?: self::buildHttpHandlerAsync();
         $transport = new RestTransport($requestBuilder, $httpHandler);
         if ($config['clientCertSource']) {

--- a/tests/Tests/Unit/InsecureRequestBuilderTest.php
+++ b/tests/Tests/Unit/InsecureRequestBuilderTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+use Google\ApiCore\InsecureRequestBuilder;
+use Google\ApiCore\Testing\MockRequestBody;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group core
+ */
+class InsecureRequestBuilderTest extends TestCase
+{
+    private $builder;
+
+    const SERVICE_NAME = 'test.interface.v1.api';
+
+    public function setUp(): void
+    {
+        $this->builder = new InsecureRequestBuilder(
+            'www.example.com',
+            __DIR__ . '/testdata/test_service_rest_client_config.php'
+        );
+    }
+
+    public function testMethodWithUrlPlaceholder()
+    {
+        $message = new MockRequestBody();
+        $message->setName('message/foo');
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithUrlPlaceholder', $message);
+        $uri = $request->getUri();
+
+        $this->assertSame('http', $uri->getScheme());
+        $this->assertEmpty($uri->getQuery());
+        $this->assertEmpty((string) $request->getBody());
+        $this->assertSame('/v1/message/foo', $uri->getPath());
+    }
+
+    public function testMethodWithBody()
+    {
+        $message = new MockRequestBody();
+        $message->setName('message/foo');
+        $nestedMessage = new MockRequestBody();
+        $nestedMessage->setName('nested/foo');
+        $message->setNestedMessage($nestedMessage);
+
+        $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBodyAndUrlPlaceholder', $message);
+        $uri = $request->getUri();
+
+        $this->assertSame('http', $uri->getScheme());
+        $this->assertEmpty($uri->getQuery());
+        $this->assertSame('/v1/message/foo', $uri->getPath());
+        $this->assertEquals(
+            ['name' => 'message/foo', 'nestedMessage' => ['name' => 'nested/foo']],
+            json_decode($request->getBody(), true)
+        );
+    }
+}

--- a/tests/Tests/Unit/InsecureRequestBuilderTest.php
+++ b/tests/Tests/Unit/InsecureRequestBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Google Inc.
+ * Copyright 2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Tests/Unit/RequestBuilderTest.php
+++ b/tests/Tests/Unit/RequestBuilderTest.php
@@ -62,6 +62,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithUrlPlaceholder', $message);
         $uri = $request->getUri();
 
+        $this->assertSame('https', $uri->getScheme());
         $this->assertEmpty($uri->getQuery());
         $this->assertEmpty((string) $request->getBody());
         $this->assertSame('/v1/message/foo', $uri->getPath());
@@ -78,6 +79,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithBodyAndUrlPlaceholder', $message);
         $uri = $request->getUri();
 
+        $this->assertSame('https', $uri->getScheme());
         $this->assertEmpty($uri->getQuery());
         $this->assertSame('/v1/message/foo', $uri->getPath());
         $this->assertEquals(
@@ -97,6 +99,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithNestedMessageAsBody', $message);
         $uri = $request->getUri();
 
+        $this->assertSame('https', $uri->getScheme());
         $this->assertEmpty($uri->getQuery());
         $this->assertSame('/v1/message/foo', $uri->getPath());
         $this->assertEquals(
@@ -161,6 +164,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithNestedUrlPlaceholder', $message);
         $uri = $request->getUri();
 
+        $this->assertSame('https', $uri->getScheme());
         $this->assertEmpty($uri->getQuery());
         $this->assertSame('/v1/nested/foo', $uri->getPath());
         $this->assertEquals(
@@ -179,6 +183,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertEmpty((string) $request->getBody());
+        $this->assertSame('https', $uri->getScheme());
         $this->assertSame('/v1/message/foo', $uri->getPath());
         $this->assertSame('repeatedField=bar1&repeatedField=bar2', $uri->getQuery());
     }
@@ -206,6 +211,7 @@ class RequestBuilderTest extends TestCase
         $request = $this->builder->build(self::SERVICE_NAME . '/MethodWithColonInUrl', $message);
         $uri = $request->getUri();
 
+        $this->assertSame('https', $uri->getScheme());
         $this->assertEmpty($uri->getQuery());
         $this->assertSame('/v1/message/foo:action', $uri->getPath());
     }
@@ -222,6 +228,7 @@ class RequestBuilderTest extends TestCase
         );
         $uri = $request->getUri();
 
+        $this->assertSame('https', $uri->getScheme());
         $this->assertEmpty($uri->getQuery());
         $this->assertSame('/v1/message/foo/number/10:action', $uri->getPath());
     }
@@ -236,7 +243,7 @@ class RequestBuilderTest extends TestCase
             $message
         );
         $uri = $request->getUri();
-
+        $this->assertSame('https', $uri->getScheme());
         $this->assertSame('/v1/message-name', $uri->getPath());
     }
 


### PR DESCRIPTION
fixes https://github.com/googleapis/google-cloud-php/issues/7187

[According to documentation](https://cloud.google.com/pubsub/docs/emulator), the Pub/Sub emulator only supports unsecure (HTTP) connections.  After updating `google/cloud-pubsub` to version 2 there was no option to use the emulator with REST transport  (without gRPC PHP extension). 
While the fix in https://github.com/googleapis/google-cloud-php/pull/7588 provided some assistance, it still required a significant amount of code to modify the client to generate URLs with the `http` protocol.

This merge request introduces `InsecureRequestBuilder` which automatically generates URLs with the http scheme, simplifying the process.