### PR TITLE
chore: misc fixes to allow for docs generation

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,0 +1,7 @@
+{
+    "language": "php",
+    "distribution_name": "google/gax",
+    "release_level": "stable",
+    "client_documentation": "https://cloud.google.com/php/docs/reference/gax/latest",
+    "library_type": "CORE"
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ more convenient and idiomatic API surface to callers.
 
 ## PHP Versions
 
-gax-php currently requires PHP 5.6 or higher.
+gax-php currently requires PHP 8.0 or higher.
 
 ## Contributing
 

--- a/src/Options/CallOptions.php
+++ b/src/Options/CallOptions.php
@@ -35,14 +35,14 @@ namespace Google\ApiCore\Options;
 use ArrayAccess;
 use Google\ApiCore\CredentialsWrapper;
 use Google\ApiCore\RetrySettings;
-use Google\ApiCore\TransportInterface;
 
 /**
  * The CallOptions class provides typing to the associative array of options
- * passed to transport RPC methods. See {@see TransportInterface::startUnaryCall()},
- * {@see TransportInterface::startBidiStreamingCall()},
- * {@see TransportInterface::startClientStreamingCall()}, and
- * {@see TransportInterface::startServerStreamingCall()}.
+ * passed to transport RPC methods. See
+ * {@see \Google\ApiCore\Transport\TransportInterface::startUnaryCall()},
+ * {@see \Google\ApiCore\Transport\TransportInterface::startBidiStreamingCall()},
+ * {@see \Google\ApiCore\Transport\TransportInterface::startClientStreamingCall()}, and
+ * {@see \Google\ApiCore\Transport\TransportInterface::startServerStreamingCall()}.
  */
 class CallOptions implements ArrayAccess
 {

--- a/src/Options/ClientOptions.php
+++ b/src/Options/ClientOptions.php
@@ -42,7 +42,8 @@ use InvalidArgumentException;
 /**
  * The ClientOptions class adds typing to the associative array of options
  * passed into each API client constructor. To use this class directly, pass
- * the result of {@see ClientOptions::toArray} to the client constructor:
+ * the result of {@see \Google\ApiCore\Options\ClientOptions::toArray()} to the
+ * client constructor:
  *
  * ```
  * use Google\ApiCore\ClientOptions;


### PR DESCRIPTION
misc fixes that will allow  googleapis/google-cloud-php#7797 to pass

 - Adds `.repo-metadata.json` to this repo
 - fixes "broken references"
 - updates outdated PHP version in README
