### PR TITLE
fix: add PHP 8.4 compatibility to last release compatible with PHP 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ "7.4", "8.0", "8.1", "8.2", "8.3" ]
+                php: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
                 extensions: [""]
                 tools: [""]
                 composerflags: [""]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,5 +74,5 @@ jobs:
       - name: Run Script
         run: |
           composer install
-          composer global require phpstan/phpstan
+          composer global require phpstan/phpstan:^1.0
           ~/.composer/vendor/bin/phpstan analyse

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -62,7 +62,7 @@ class ApiException extends Exception
     public function __construct(
         string $message,
         int $code,
-        string $status = null,
+        ?string $status = null,
         array $optionalArgs = []
     ) {
         $optionalArgs += [
@@ -163,8 +163,8 @@ class ApiException extends Exception
     public static function createFromApiResponse(
         $basicMessage,
         $rpcCode,
-        array $metadata = null,
-        Exception $previous = null
+        ?array $metadata = null,
+        ?Exception $previous = null
     ) {
         return self::create(
             $basicMessage,
@@ -187,8 +187,8 @@ class ApiException extends Exception
     public static function createFromRestApiResponse(
         $basicMessage,
         $rpcCode,
-        array $metadata = null,
-        Exception $previous = null
+        ?array $metadata = null,
+        ?Exception $previous = null
     ) {
         return self::create(
             $basicMessage,
@@ -244,7 +244,7 @@ class ApiException extends Exception
         int $rpcCode,
         $metadata,
         array $decodedMetadata,
-        Exception $previous = null
+        ?Exception $previous = null
     ) {
         $containsErrorInfo = self::containsErrorInfo($decodedMetadata);
         $rpcStatus = ApiStatus::statusFromRpcCode($rpcCode);

--- a/src/Call.php
+++ b/src/Call.php
@@ -61,7 +61,7 @@ class Call
      */
     public function __construct(
         string $method,
-        string $decodeType = null,
+        ?string $decodeType = null,
         $message = null,
         $descriptor = [],
         int $callType = Call::UNARY_CALL

--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -77,7 +77,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
      */
     public function __construct(
         FetchAuthTokenInterface $credentialsFetcher,
-        callable $authHttpHandler = null,
+        ?callable $authHttpHandler = null,
         string $universeDomain = GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN
     ) {
         $this->credentialsFetcher = $credentialsFetcher;
@@ -203,7 +203,7 @@ class CredentialsWrapper implements ProjectIdProviderInterface
         return null;
     }
 
-    public function getProjectId(callable $httpHandler = null): ?string
+    public function getProjectId(?callable $httpHandler = null): ?string
     {
         // Ensure that FetchAuthTokenCache does not throw an exception
         if ($this->credentialsFetcher instanceof FetchAuthTokenCache
@@ -313,12 +313,12 @@ class CredentialsWrapper implements ProjectIdProviderInterface
      * @throws ValidationException
      */
     private static function buildApplicationDefaultCredentials(
-        array $scopes = null,
-        callable $authHttpHandler = null,
-        array $authCacheOptions = null,
-        CacheItemPoolInterface $authCache = null,
+        ?array $scopes = null,
+        ?callable $authHttpHandler = null,
+        ?array $authCacheOptions = null,
+        ?CacheItemPoolInterface $authCache = null,
         $quotaProject = null,
-        array $defaultScopes = null
+        ?array $defaultScopes = null
     ) {
         try {
             return ApplicationDefaultCredentials::getCredentials(

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -315,7 +315,7 @@ trait GapicClientTrait
         string $apiEndpoint,
         $transport,
         $transportConfig,
-        callable $clientCertSource = null
+        ?callable $clientCertSource = null
     ) {
         if (!is_string($transport)) {
             throw new ValidationException(
@@ -511,7 +511,7 @@ trait GapicClientTrait
      */
     private function startApiCall(
         string $methodName,
-        Message $request = null,
+        ?Message $request = null,
         array $optionalArgs = []
     ) {
         $methodDescriptors =$this->validateCallConfig($methodName);
@@ -573,9 +573,9 @@ trait GapicClientTrait
         string $methodName,
         string $decodeType,
         array $optionalArgs = [],
-        Message $request = null,
+        ?Message $request = null,
         int $callType = Call::UNARY_CALL,
-        string $interfaceName = null
+        ?string $interfaceName = null
     ) {
         $optionalArgs = $this->configureCallOptions($optionalArgs);
         $callStack = $this->createCallStack(
@@ -713,8 +713,8 @@ trait GapicClientTrait
         array $optionalArgs,
         Message $request,
         $client,
-        string $interfaceName = null,
-        string $operationClass = null
+        ?string $interfaceName = null,
+        ?string $operationClass = null
     ) {
         $optionalArgs = $this->configureCallOptions($optionalArgs);
         $callStack = $this->createCallStack(
@@ -769,7 +769,7 @@ trait GapicClientTrait
         array $optionalArgs,
         string $decodeType,
         Message $request,
-        string $interfaceName = null
+        ?string $interfaceName = null
     ) {
         return $this->getPagedListResponseAsync(
             $methodName,
@@ -794,7 +794,7 @@ trait GapicClientTrait
         array $optionalArgs,
         string $decodeType,
         Message $request,
-        string $interfaceName = null
+        ?string $interfaceName = null
     ) {
         $optionalArgs = $this->configureCallOptions($optionalArgs);
         $callStack = $this->createCallStack(
@@ -825,7 +825,7 @@ trait GapicClientTrait
      *
      * @return string
      */
-    private function buildMethod(string $interfaceName = null, string $methodName = null)
+    private function buildMethod(?string $interfaceName = null, ?string $methodName = null)
     {
         return sprintf(
             '%s/%s',
@@ -840,7 +840,7 @@ trait GapicClientTrait
      *
      * @return array
      */
-    private function buildRequestParamsHeader(array $headerParams, Message $request = null)
+    private function buildRequestParamsHeader(array $headerParams, ?Message $request = null)
     {
         $headers = [];
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -110,7 +110,7 @@ class Page implements IteratorAggregate
      * @throws ApiException if the call to fetch the next page fails.
      * @return Page
      */
-    public function getNextPage(int $pageSize = null)
+    public function getNextPage(?int $pageSize = null)
     {
         if (!$this->hasNextPage()) {
             throw new ValidationException(

--- a/src/PathTemplate.php
+++ b/src/PathTemplate.php
@@ -54,7 +54,7 @@ class PathTemplate implements ResourceTemplateInterface
      * @param string $path A path template string
      * @throws ValidationException When $path cannot be parsed into a valid PathTemplate
      */
-    public function __construct(string $path = null)
+    public function __construct(?string $path = null)
     {
         if (empty($path)) {
             throw new ValidationException('Cannot construct PathTemplate from empty string');

--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -233,7 +233,7 @@ class RequestBuilder
         foreach ($placeholders as $placeholder => $metadata) {
             $value = array_reduce(
                 $metadata['getters'],
-                function (Message $result = null, $getter) {
+                function (?Message $result = null, $getter = null) {
                     if ($result) {
                         return $result->$getter();
                     }

--- a/src/ResourceHelperTrait.php
+++ b/src/ResourceHelperTrait.php
@@ -84,7 +84,7 @@ trait ResourceHelperTrait
         return self::$templateMap[$key] ?? null;
     }
 
-    private static function parseFormattedName(string $formattedName, string $template = null): array
+    private static function parseFormattedName(string $formattedName, ?string $template = null): array
     {
         if (is_null(self::$templateMap)) {
             self::registerPathTemplates();

--- a/src/ResourceTemplate/Parser.php
+++ b/src/ResourceTemplate/Parser.php
@@ -48,7 +48,7 @@ class Parser
      * @return array
      * @throws ValidationException
      */
-    public static function parseSegments(string $path = null)
+    public static function parseSegments(?string $path = null)
     {
         if (empty($path)) {
             throw new ValidationException("Cannot parse empty path");

--- a/src/ResourceTemplate/RelativeResourceTemplate.php
+++ b/src/ResourceTemplate/RelativeResourceTemplate.php
@@ -287,7 +287,7 @@ class RelativeResourceTemplate implements ResourceTemplateInterface
      * @param string|null $separator An optional string separator
      * @return array[] A list of [string, Segment] tuples
      */
-    private static function buildKeySegmentTuples(array $segments, string $separator = null)
+    private static function buildKeySegmentTuples(array $segments, ?string $separator = null)
     {
         $keySegmentTuples = [];
         $positionalArgumentCounter = 0;

--- a/src/ResourceTemplate/Segment.php
+++ b/src/ResourceTemplate/Segment.php
@@ -65,9 +65,9 @@ class Segment
      */
     public function __construct(
         int $segmentType,
-        string $value = null,
-        string $key = null,
-        RelativeResourceTemplate $template = null,
+        ?string $value = null,
+        ?string $key = null,
+        ?RelativeResourceTemplate $template = null,
         string $separator = '/'
     ) {
         $this->segmentType = $segmentType;

--- a/src/Testing/MockBidiStreamingCall.php
+++ b/src/Testing/MockBidiStreamingCall.php
@@ -59,7 +59,7 @@ class MockBidiStreamingCall extends Grpc\BidiStreamingCall
      * @param mixed|null $deserialize An optional deserialize method for the response object.
      * @param stdClass|null $status An optional status object. If set to null, a status of OK is used.
      */
-    public function __construct(array $responses, $deserialize = null, stdClass $status = null)
+    public function __construct(array $responses, $deserialize = null, ?stdClass $status = null)
     {
         $this->responses = $responses;
         $this->deserialize = $deserialize;

--- a/src/Testing/MockClientStreamingCall.php
+++ b/src/Testing/MockClientStreamingCall.php
@@ -62,7 +62,7 @@ class MockClientStreamingCall extends Grpc\ClientStreamingCall
      * @param callable|array|null $deserialize An optional deserialize method for the response object.
      * @param stdClass|null $status An optional status object. If set to null, a status of OK is used.
      */
-    public function __construct($response, $deserialize = null, stdClass $status = null)
+    public function __construct($response, $deserialize = null, ?stdClass $status = null)
     {
         $this->mockUnaryCall = new MockUnaryCall($response, $deserialize, $status);
     }

--- a/src/Testing/MockServerStreamingCall.php
+++ b/src/Testing/MockServerStreamingCall.php
@@ -57,7 +57,7 @@ class MockServerStreamingCall extends \Grpc\ServerStreamingCall implements Serve
      * @param callable|array|null $deserialize An optional deserialize method for the response object.
      * @param stdClass|null $status An optional status object. If set to null, a status of OK is used.
      */
-    public function __construct(array $responses, $deserialize = null, stdClass $status = null)
+    public function __construct(array $responses, $deserialize = null, ?stdClass $status = null)
     {
         $this->responses = $responses;
         $this->deserialize = $deserialize;

--- a/src/Testing/MockStatus.php
+++ b/src/Testing/MockStatus.php
@@ -44,7 +44,7 @@ class MockStatus extends stdClass
     public $code;
     public $details;
     public $metadata;
-    public function __construct($code, string $details = null, array $metadata = [])
+    public function __construct($code, ?string $details = null, array $metadata = [])
     {
         $this->code = $code;
         $this->details = $details;

--- a/src/Testing/MockStubTrait.php
+++ b/src/Testing/MockStubTrait.php
@@ -52,7 +52,7 @@ trait MockStubTrait
     private $callObjects = [];
     private $deserialize;
 
-    public function __construct(callable $deserialize = null)
+    public function __construct(?callable $deserialize = null)
     {
         $this->deserialize = $deserialize;
     }
@@ -196,7 +196,7 @@ trait MockStubTrait
      * @param \Google\Protobuf\Internal\Message $response
      * @param stdClass $status
      */
-    public function addResponse($response, stdClass $status = null)
+    public function addResponse($response, ?stdClass $status = null)
     {
         if (!$this->deserialize && $response) {
             $this->deserialize = [get_class($response), 'decode'];
@@ -263,7 +263,7 @@ trait MockStubTrait
      * @param callable $deserialize
      * @return static An instance of the current class type.
      */
-    public static function create($responseObject, stdClass $status = null, callable $deserialize = null)
+    public static function create($responseObject, ?stdClass $status = null, ?callable $deserialize = null)
     {
         $stub = new static($deserialize); // @phpstan-ignore-line
         $stub->addResponse($responseObject, $status);
@@ -277,7 +277,7 @@ trait MockStubTrait
      * @param stdClass $finalStatus
      * @return static An instance of the current class type.
      */
-    public static function createWithResponseSequence(array $sequence, callable $deserialize = null, stdClass $finalStatus = null)
+    public static function createWithResponseSequence(array $sequence, ?callable $deserialize = null, ?stdClass $finalStatus = null)
     {
         $stub = new static($deserialize); // @phpstan-ignore-line
         foreach ($sequence as $elem) {

--- a/src/Testing/MockUnaryCall.php
+++ b/src/Testing/MockUnaryCall.php
@@ -59,7 +59,7 @@ class MockUnaryCall extends \Grpc\UnaryCall
      * @param callable|array|null $deserialize An optional deserialize method for the response object.
      * @param stdClass|null $status An optional status object. If set to null, a status of OK is used.
      */
-    public function __construct($response = null, $deserialize = null, stdClass $status = null)
+    public function __construct($response = null, $deserialize = null, ?stdClass $status = null)
     {
         $this->response = $response;
         $this->deserialize = $deserialize;

--- a/src/Transport/GrpcTransport.php
+++ b/src/Transport/GrpcTransport.php
@@ -77,7 +77,7 @@ class GrpcTransport extends BaseStub implements TransportInterface
      *        extends {@see Grpc\Interceptor}.
      * @throws Exception
      */
-    public function __construct(string $hostname, array $opts, Channel $channel = null, array $interceptors = [])
+    public function __construct(string $hostname, array $opts, ?Channel $channel = null, array $interceptors = [])
     {
         if ($interceptors) {
             $channel = Interceptor::intercept(


### PR DESCRIPTION
Ensures that the last GAX release which is compatible with PHP 7.4 will be compatible with PHP 8.4 as well.

Once this is merged, we will tag this as `v1.29.2`

fixes https://github.com/googleapis/gax-php/issues/596