### PR TITLE
Revert "chore: drop support for PHP 8.0"

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,13 +5,13 @@ branchProtectionRules:
 - pattern: main
   isAdminEnforced: true
   requiredStatusCheckContexts:
+    - 'PHP 8.0 Unit Test'
+    - 'PHP 8.0 Unit Test protobuf,grpc'
+    - 'PHP 8.0 Unit Test --prefer-lowest'
     - 'PHP 8.1 Unit Test'
-    - 'PHP 8.1 Unit Test protobuf,grpc'
-    - 'PHP 8.1 Unit Test --prefer-lowest'
     - 'PHP 8.2 Unit Test'
     - 'PHP 8.3 Unit Test'
-    - 'PHP 8.4 Unit Test'
-    - 'PHP 8.4 Unit Test protobuf,grpc'
+    - 'PHP 8.3 Unit Test protobuf,grpc'
     - 'Run google-cloud-php tests'
     - 'PHP Style Check / PHP Code Standards'
     - 'PHPStan Static Analysis / PHPStan Static Analysis'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
                   - php: "8.0"
                     extensions: "protobuf,grpc"
                     tools: "pecl"
-                  - php: "8.3"
+                  - php: "8.4"
                     extensions: "protobuf,grpc"
                     tools: "pecl"
                   - php: "8.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,18 +11,18 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ "8.1", "8.2", "8.3", "8.4" ]
+                php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
                 extensions: [""]
                 tools: [""]
                 composerflags: [""]
                 include:
-                  - php: "8.1"
+                  - php: "8.0"
                     extensions: "protobuf,grpc"
                     tools: "pecl"
-                  - php: "8.4"
+                  - php: "8.3"
                     extensions: "protobuf,grpc"
                     tools: "pecl"
-                  - php: "8.1"
+                  - php: "8.0"
                     composerflags: "--prefer-lowest"
         name: "PHP ${{ matrix.php }} Unit Test ${{ matrix.extensions }}${{ matrix.composerflags }}"
         steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ more convenient and idiomatic API surface to callers.
 
 ## PHP Versions
 
-gax-php currently requires PHP 8.1 or higher.
+gax-php currently requires PHP 8.0 or higher.
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/googleapis/gax-php",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "google/auth": "^1.34.0",
         "google/grpc-gcp": "^0.4",
         "grpc/grpc": "^1.13",


### PR DESCRIPTION
Reverts googleapis/gax-php#598, we will drop PHP 8.0 next year

See https://github.com/googleapis/google-auth-library-php/pull/594