### PR TITLE
Add missing withResponseMetadata option

### DIFF
--- a/src/Options/CallOptions.php
+++ b/src/Options/CallOptions.php
@@ -54,6 +54,7 @@ class CallOptions implements ArrayAccess
 
     /** @var RetrySettings|array|null $retrySettings */
     private $retrySettings;
+    private bool $withResponseMetadata;
 
     /**
      * @param array $options {
@@ -88,6 +89,7 @@ class CallOptions implements ArrayAccess
         $this->setTimeoutMillis($arr['timeoutMillis'] ?? null);
         $this->setTransportOptions($arr['transportOptions'] ?? []);
         $this->setRetrySettings($arr['retrySettings'] ?? null);
+        $this->setWithResponseMetadata($arr['withResponseMetadata'] ?? false);
     }
 
     /**
@@ -96,6 +98,14 @@ class CallOptions implements ArrayAccess
     public function setHeaders(array $headers)
     {
         $this->headers = $headers;
+    }
+
+    /**
+     * @param bool $withResponseMetadata
+     */
+    public function setWithResponseMetadata(bool $withResponseMetadata)
+    {
+        $this->withResponseMetadata = $withResponseMetadata;
     }
 
     /**


### PR DESCRIPTION
 The withResponseMetadata option was missing from this library https://github.com/googleads/google-ads-php/blob/main/src/Google/Ads/GoogleAds/Lib/V17/UnaryGoogleAdsResponseMetadataCallable.php\#L48 because it was using gax-php.

A discussion ticket has been opened here https://github.com/googleads/google-ads-php/issues/1050