### PR TITLE
feat: Expose errors with the correct protobuf type

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -179,11 +179,13 @@ class ApiException extends Exception
         ?array $metadata = null,
         ?Exception $previous = null
     ) {
+        $errors = [];
         return self::create(
             $basicMessage,
             $rpcCode,
             $metadata,
-            Serializer::decodeMetadata((array) $metadata),
+            Serializer::decodeMetadata((array) $metadata, $errors),
+            $errors,
             $previous
         );
     }
@@ -208,6 +210,7 @@ class ApiException extends Exception
             $rpcCode,
             $metadata,
             is_null($metadata) ? [] : $metadata,
+            Serializer::encodeMetadataToProtobufErrors($metadata),
             $previous
         );
     }

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -144,7 +144,7 @@ class ApiException extends Exception
      * Returns the unserialized errors
      * @return array
      */
-    public function getUnserializedErrors(): array
+    public function getErrorDetails(): array
     {
         return $this->protobufErrors;
     }

--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -210,7 +210,7 @@ class ApiException extends Exception
             $rpcCode,
             $metadata,
             is_null($metadata) ? [] : $metadata,
-            Serializer::encodeMetadataToProtobufErrors($metadata),
+            Serializer::encodeMetadataToProtobufErrors($metadata ?? []),
             $previous
         );
     }
@@ -291,7 +291,7 @@ class ApiException extends Exception
                 'metadata' => $metadata,
                 'basicMessage' => $basicMessage,
             ],
-            $protobufErrors
+            $protobufErrors ?? []
         );
     }
 

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -164,6 +164,34 @@ class Serializer
     }
 
     /**
+     * Encodes decoded metadata to the Protobuf error type
+     *
+     * @param array metadata
+     * @return array
+     */
+    public static function encodeMetadataToProtobufErrors(array $metadata): array
+    {
+        $result = [];
+
+        foreach ($metadata as $error) {
+            $message = null;
+            $type = $error['@type'];
+
+            if (!isset(self::$metadataKnownTypes[$type])) {
+                continue;
+            }
+
+            $class = self::$metadataKnownTypes[$type];
+            $message = new $class;
+            $jsonMessage = json_encode(array_diff($error, ['@type' => $error['@type']]));
+            $message->mergeFromJsonString($jsonMessage);
+            $result[] = $message;
+        }
+
+        return $result;
+    }
+
+    /**
      * @param Message $message
      * @return string Json representation of $message
      * @throws ValidationException

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -175,6 +175,11 @@ class Serializer
 
         foreach ($metadata as $error) {
             $message = null;
+
+            if (!isset($error['@type'])) {
+                continue;
+            }
+
             $type = $error['@type'];
 
             if (!isset(self::$metadataKnownTypes[$type])) {
@@ -183,7 +188,7 @@ class Serializer
 
             $class = self::$metadataKnownTypes[$type];
             $message = new $class;
-            $jsonMessage = json_encode(array_diff($error, ['@type' => $error['@type']]));
+            $jsonMessage = json_encode(array_diff_key($error, ['@type' => true]));
             $message->mergeFromJsonString($jsonMessage);
             $result[] = $message;
         }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -63,6 +63,15 @@ class Serializer
         'google.rpc.errorinfo-bin' => \Google\Rpc\ErrorInfo::class,
         'google.rpc.help-bin' => \Google\Rpc\Help::class,
         'google.rpc.localizedmessage-bin' => \Google\Rpc\LocalizedMessage::class,
+        'type.googleapis.com/google.rpc.RetryInfo' => \Google\Rpc\RetryInfo::class,
+        'type.googleapis.com/google.rpc.DebugInfo' => \Google\Rpc\DebugInfo::class,
+        'type.googleapis.com/google.rpc.QuotaFailure' => \Google\Rpc\QuotaFailure::class,
+        'type.googleapis.com/google.rpc.BadRequest' => \Google\Rpc\BadRequest::class,
+        'type.googleapis.com/google.rpc.RequestInfo' => \Google\Rpc\RequestInfo::class,
+        'type.googleapis.com/google.rpc.ResourceInfo' => \Google\Rpc\ResourceInfo::class,
+        'type.googleapis.com/google.rpc.ErrorInfo' => \Google\Rpc\ErrorInfo::class,
+        'type.googleapis.com/google.rpc.Help' => \Google\Rpc\Help::class,
+        'type.googleapis.com/google.rpc.LocalizedMessage' => \Google\Rpc\LocalizedMessage::class,
     ];
 
     private $fieldTransformers;
@@ -178,9 +187,10 @@ class Serializer
      * Decode metadata received from gRPC status object
      *
      * @param array $metadata
+     * @param array $errors
      * @return array
      */
-    public static function decodeMetadata(array $metadata)
+    public static function decodeMetadata(array $metadata, array &$errors = null)
     {
         if (count($metadata) == 0) {
             return [];
@@ -199,6 +209,9 @@ class Serializer
                         try {
                             $message->mergeFromString($value);
                             $decodedValue += self::serializeToPhpArray($message);
+                            if (!is_null($errors)) {
+                                $errors[] = $message;
+                            }
                         } catch (\Exception $e) {
                             // We encountered an error trying to deserialize the data
                             $decodedValue += [

--- a/tests/Unit/ApiExceptionTest.php
+++ b/tests/Unit/ApiExceptionTest.php
@@ -71,7 +71,7 @@ class ApiExceptionTest extends TestCase
         $this->assertSame(Code::OK, $apiException->getCode());
         $this->assertSame($expectedMessage, $apiException->getMessage());
         $this->assertNull($apiException->getMetadata());
-        $this->assertEmpty($apiException->getUnserializedErrors());
+        $this->assertEmpty($apiException->getErrorDetails());
     }
 
     /**
@@ -96,7 +96,7 @@ class ApiExceptionTest extends TestCase
         $this->assertSame(Code::OK, $apiException->getCode());
         $this->assertSame($expectedMessageWithoutErrorDetails, $apiException->getMessage());
         $this->assertSame($metadata, $apiException->getMetadata());
-        $this->assertCount($unserializedErrorsCount ,$apiException->getUnserializedErrors());
+        $this->assertCount($unserializedErrorsCount ,$apiException->getErrorDetails());
     }
 
     /**
@@ -121,7 +121,7 @@ class ApiExceptionTest extends TestCase
         $this->assertSame(Code::OK, $apiException->getCode());
         $this->assertSame($expectedMessage, $apiException->getMessage());
         $this->assertSame($metadata, $apiException->getMetadata());
-        $this->assertCount($unserializedErrorsCount ,$apiException->getUnserializedErrors());
+        $this->assertCount($unserializedErrorsCount ,$apiException->getErrorDetails());
     }
 
     public function getMetadata()
@@ -341,7 +341,7 @@ class ApiExceptionTest extends TestCase
         ];
     }
 
-    public function testGetUnserializedErrors()
+    public function testGetErrorDetails()
     {
         $metadata = [
             [
@@ -397,7 +397,7 @@ class ApiExceptionTest extends TestCase
         ], JSON_PRETTY_PRINT);
 
         $this->assertSame($expectedMessage, $apiException->getMessage());
-        $this->assertCount(8, $apiException->getUnserializedErrors());
+        $this->assertCount(8, $apiException->getErrorDetails());
         $this->assertSame(null, $apiException->getReason());
         $this->assertSame(null, $apiException->getDomain());
         $this->assertSame(null, $apiException->getErrorInfoMetadata());


### PR DESCRIPTION
Adds a method that exposes the underlying protobuf errors via the `ApiException::getErrorDetails` method.

b/374174649