### PR TITLE
surface errors: add fix for compliance

### DIFF
--- a/src/ApiException.php
+++ b/src/ApiException.php
@@ -157,11 +157,22 @@ class ApiException extends Exception
     {
         $metadata = property_exists($status, 'metadata') ? $status->metadata : null;
         $errors = [];
+        if (isset($metadata['grpc-status-details-bin'])) {
+             $decodedStatus = new \Google\Rpc\Status();
+             $decodedStatus->mergeFromString($metadata['grpc-status-details-bin'][0]);
+             foreach ($decodedStatus->getDetails() as $any) {
+                 if (isset(KnownTypes::JSON_TYPES[$any->getTypeUrl()])) {
+                     $class = KnownTypes::JSON_TYPES[$any->getTypeUrl()];
+                     new $class(); // add known types to descriptor pool
+                 }
+                 $errors[] = $any->unpack();
+             }
+        }
         return self::create(
             $status->details,
             $status->code,
             $metadata,
-            Serializer::decodeMetadata((array) $metadata, $errors),
+            Serializer::decodeMetadata((array) $metadata),
             $errors,
         );
     }


### PR DESCRIPTION
This seems to fix the issues from GAPIC Showcase where Rest and gRPC return different error details. 

See [@gapic-generator-php/tests/Conformance/ShowcaseTest.php](https://github.com/googleapis/gapic-generator-php/pull/753/files#diff-880c3caff17fac35f0b85b4830deb9115e8821fbd85edc5f1bae011d4842f281)