### PR TITLE
chore: drop PHP 8.0

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -5,10 +5,9 @@ branchProtectionRules:
 - pattern: main
   isAdminEnforced: true
   requiredStatusCheckContexts:
-    - 'PHP 8.0 Unit Test'
-    - 'PHP 8.0 Unit Test protobuf,grpc'
-    - 'PHP 8.0 Unit Test --prefer-lowest'
     - 'PHP 8.1 Unit Test'
+    - 'PHP 8.1 Unit Test protobuf,grpc'
+    - 'PHP 8.1 Unit Test --prefer-lowest'
     - 'PHP 8.2 Unit Test'
     - 'PHP 8.3 Unit Test'
     - 'PHP 8.4 Unit Test'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,18 +11,18 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+                php: [ "8.1", "8.2", "8.3", "8.4" ]
                 extensions: [""]
                 tools: [""]
                 composerflags: [""]
                 include:
-                  - php: "8.0"
+                  - php: "8.1"
                     extensions: "protobuf,grpc"
                     tools: "pecl"
                   - php: "8.4"
                     extensions: "protobuf,grpc"
                     tools: "pecl"
-                  - php: "8.0"
+                  - php: "8.1"
                     composerflags: "--prefer-lowest"
         name: "PHP ${{ matrix.php }} Unit Test ${{ matrix.extensions }}${{ matrix.composerflags }}"
         steps:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ more convenient and idiomatic API surface to callers.
 
 ## PHP Versions
 
-gax-php currently requires PHP 8.0 or higher.
+gax-php currently requires PHP 8.1 or higher.
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/googleapis/gax-php",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "google/auth": "^1.45",
         "google/grpc-gcp": "^0.4",
         "grpc/grpc": "^1.13",


### PR DESCRIPTION
We are now 20 months past the EOL of PHP 8.0, and support should be dropped

This is also outside our "[Foundational PHP Support](https://github.com/google/oss-policies-info/blob/main/foundational-php-support-matrix.md)" 

See https://github.com/googleapis/google-auth-library-php/pull/620
See https://github.com/googleapis/google-cloud-php/pull/8449