### PR TITLE
docs: add template for operation result

### DIFF
--- a/src/OperationResponse.php
+++ b/src/OperationResponse.php
@@ -56,6 +56,8 @@ use LogicException;
  * more control is required, it is possible to make calls against the
  * Operations API directly instead of via the OperationResponse object
  * using an Operations Client instance.
+ *
+ * @template T
  */
 class OperationResponse
 {
@@ -280,9 +282,10 @@ class OperationResponse
     }
 
     /**
-     * Return the result of the operation. If operationSucceeded() is false, return null.
+     * Return the result of the operation. If operationSucceeded() is false,
+     * return null.
      *
-     * @return mixed|null The result of the operation, or null if operationSucceeded() is false
+     * @return T|null
      */
     public function getResult()
     {

--- a/src/OperationResponse.php
+++ b/src/OperationResponse.php
@@ -57,7 +57,7 @@ use LogicException;
  * Operations API directly instead of via the OperationResponse object
  * using an Operations Client instance.
  *
- * @template T
+ * @template T = mixed
  */
 class OperationResponse
 {

--- a/src/ServerStream.php
+++ b/src/ServerStream.php
@@ -39,6 +39,8 @@ use Psr\Log\LoggerInterface;
 
 /**
  * ServerStream is the response object from a server streaming API call.
+ *
+ * @template T = mixed
  */
 class ServerStream
 {
@@ -72,7 +74,7 @@ class ServerStream
      * completes. Throws an ApiException if the streaming call failed.
      *
      * @throws ApiException
-     * @return \Generator|mixed
+     * @return \Generator<int, T>|mixed
      */
     public function readAll()
     {


### PR DESCRIPTION
required for https://github.com/googleapis/gapic-generator-php/pull/767

ensures that PHPStan understands the "generic" syntax used in the GAPIC generator for LROs