### PR TITLE
feat: support client options in ClientOptionsTrait::buildClientOptions

### DIFF
--- a/src/ClientOptionsTrait.php
+++ b/src/ClientOptionsTrait.php
@@ -32,6 +32,7 @@
 
 namespace Google\ApiCore;
 
+use Google\ApiCore\Options\ClientOptions;
 use Google\Auth\ApplicationDefaultCredentials;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\FetchAuthTokenInterface;
@@ -84,8 +85,26 @@ trait ClientOptionsTrait
         return [];
     }
 
-    private function buildClientOptions(array $options)
+    /**
+     * Resolve client options based on the client's default
+     * ({@see ClientOptionsTrait::getClientDefault}) and the default for all
+     * Google APIs.
+     *
+     * 1. Set default client option values
+     * 2. Set default logger (and log user-supplied configuration options)
+     * 3. Set default transport configuration
+     * 4. Call "modifyClientOptions" (for backwards compatibility)
+     * 5. Use "defaultScopes" when custom endpoint is supplied
+     * 6. Load mTLS from the environment if configured
+     * 7. Resolve endpoint based on universe domain template when possible
+     * 8. Load sysvshm grpc config when possible
+     */
+    private function buildClientOptions(array|ClientOptions $options)
     {
+        if ($options instanceof ClientOptions) {
+            $options = $options->toArray();
+        }
+
         // Build $defaultOptions starting from top level
         // variables, then going into deeper nesting, so that
         // we will not encounter missing keys

--- a/src/Options/CallOptions.php
+++ b/src/Options/CallOptions.php
@@ -44,7 +44,7 @@ use Google\ApiCore\RetrySettings;
  * {@see \Google\ApiCore\Transport\TransportInterface::startClientStreamingCall()}, and
  * {@see \Google\ApiCore\Transport\TransportInterface::startServerStreamingCall()}.
  */
-class CallOptions implements ArrayAccess
+class CallOptions implements ArrayAccess, OptionsInterface
 {
     use OptionsTrait;
 

--- a/src/Options/ClientOptions.php
+++ b/src/Options/ClientOptions.php
@@ -59,7 +59,7 @@ use Psr\Log\LoggerInterface;
  * Note: It's possible to pass an associative array to the API clients as well,
  * as ClientOptions will still be used internally for validation.
  */
-class ClientOptions implements ArrayAccess
+class ClientOptions implements ArrayAccess, OptionsInterface
 {
     use OptionsTrait;
 

--- a/src/Options/OptionsTrait.php
+++ b/src/Options/OptionsTrait.php
@@ -83,7 +83,9 @@ trait OptionsTrait
     {
         $arr = [];
         foreach (get_object_vars($this) as $key => $value) {
-            $arr[$key] = $value;
+            $arr[$key] = $value instanceof OptionsInterface
+                 ? $value->toArray()
+                 : $value;
         }
         return $arr;
     }

--- a/src/Options/TransportOptions.php
+++ b/src/Options/TransportOptions.php
@@ -37,7 +37,7 @@ use Google\ApiCore\Options\TransportOptions\GrpcFallbackTransportOptions;
 use Google\ApiCore\Options\TransportOptions\GrpcTransportOptions;
 use Google\ApiCore\Options\TransportOptions\RestTransportOptions;
 
-class TransportOptions implements ArrayAccess
+class TransportOptions implements ArrayAccess, OptionsInterface
 {
     use OptionsTrait;
 

--- a/src/Options/TransportOptions/GrpcFallbackTransportOptions.php
+++ b/src/Options/TransportOptions/GrpcFallbackTransportOptions.php
@@ -34,6 +34,7 @@ namespace Google\ApiCore\Options\TransportOptions;
 
 use ArrayAccess;
 use Closure;
+use Google\ApiCore\Options\OptionsInterface;
 use Google\ApiCore\Options\OptionsTrait;
 use Psr\Log\LoggerInterface;
 
@@ -41,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * The GrpcFallbackTransportOptions class provides typing to the associative array of options used
  * to configure {@see \Google\ApiCore\Transport\GrpcFallbackTransport}.
  */
-class GrpcFallbackTransportOptions implements ArrayAccess
+class GrpcFallbackTransportOptions implements ArrayAccess, OptionsInterface
 {
     use OptionsTrait;
 

--- a/src/Options/TransportOptions/GrpcTransportOptions.php
+++ b/src/Options/TransportOptions/GrpcTransportOptions.php
@@ -34,6 +34,7 @@ namespace Google\ApiCore\Options\TransportOptions;
 
 use ArrayAccess;
 use Closure;
+use Google\ApiCore\Options\OptionsInterface;
 use Google\ApiCore\Options\OptionsTrait;
 use Google\ApiCore\Transport\Grpc\UnaryInterceptorInterface;
 use Grpc\Channel;
@@ -44,7 +45,7 @@ use Psr\Log\LoggerInterface;
  * The GrpcTransportOptions class provides typing to the associative array of options used to
  * configure {@see \Google\ApiCore\Transport\GrpcTransport}.
  */
-class GrpcTransportOptions implements ArrayAccess
+class GrpcTransportOptions implements ArrayAccess, OptionsInterface
 {
     use OptionsTrait;
 

--- a/src/Options/TransportOptions/RestTransportOptions.php
+++ b/src/Options/TransportOptions/RestTransportOptions.php
@@ -34,6 +34,7 @@ namespace Google\ApiCore\Options\TransportOptions;
 
 use ArrayAccess;
 use Closure;
+use Google\ApiCore\Options\OptionsInterface;
 use Google\ApiCore\Options\OptionsTrait;
 use Psr\Log\LoggerInterface;
 
@@ -41,7 +42,7 @@ use Psr\Log\LoggerInterface;
  * The RestTransportOptions class provides typing to the associative array of options used to
  * configure {@see \Google\ApiCore\Transport\RestTransport}.
  */
-class RestTransportOptions implements ArrayAccess
+class RestTransportOptions implements ArrayAccess, OptionsInterface
 {
     use OptionsTrait;
 

--- a/tests/Unit/ClientOptionsTraitTest.php
+++ b/tests/Unit/ClientOptionsTraitTest.php
@@ -34,6 +34,7 @@ namespace Google\ApiCore\Tests\Unit;
 
 use Google\ApiCore\ClientOptionsTrait;
 use Google\ApiCore\CredentialsWrapper;
+use Google\ApiCore\Options\ClientOptions;
 use Google\ApiCore\ValidationException;
 use Google\Auth\CredentialsLoader;
 use Google\Auth\FetchAuthTokenInterface;
@@ -556,6 +557,16 @@ class ClientOptionsTraitTest extends TestCase
         $options = $client->buildClientOptions([]);
         $options2 = $client->buildClientOptions($options);
         $this->assertEquals($options, $options2);
+    }
+
+    public function testBuildClientOptionsWithClientOptions()
+    {
+        $client = new StubClientOptionsClient();
+        $clientOptions = new ClientOptions([]);
+        $clientOptions->setApiEndpoint('TestEndpoint.com');
+        $builtOptions = $client->buildClientOptions($clientOptions);
+
+        $this->assertEquals($clientOptions['apiEndpoint'], $builtOptions['apiEndpoint']);
     }
 
     /**


### PR DESCRIPTION
 - alternative to https://github.com/googleapis/gax-php/pull/580
 - required for https://github.com/googleapis/gapic-generator-php/pull/725

I see two ways to support `ClientOptions` for `ClientOptionsTrait::buildClientOptions`:

1. Call `toArray` on `ClientOptions` and keep the logic the same (what we have in this PR)
   - simplest way
   - means that we convert options passed in as `ClientOptions` to an array and then back again (not so good)

2. Refactor this class to have a _new_ method which takes `ClientOptions`, and remove all the backwards compatibility stuff
   - this would be best for the long-run
   - would require a bit more work

TODO: prototype option 2 to see if it's feasible