### PR TITLE
fix: ensure compute request build parameters have the operation ID last

### DIFF
--- a/tests/Unit/OperationResponseTest.php
+++ b/tests/Unit/OperationResponseTest.php
@@ -274,7 +274,14 @@ class OperationResponseTest extends TestCase
                 $phpunit->assertEquals('test-123', $request->name);
                 $phpunit->assertEquals('arg2', $request->arg2);
                 $phpunit->assertEquals('arg3', $request->arg3);
-                return new \stdClass();
+                return new class {
+                    public function getDone() {
+                        return true;
+                    }
+                    public function getError() {
+                        return false;
+                    }
+                };
             });
         $operationClient->cancelNewSurfaceOperation(Argument::type(Client\CancelOperationRequest::class))
             ->shouldBeCalledOnce()
@@ -310,6 +317,11 @@ class OperationResponseTest extends TestCase
 
         // Test getOperationMethod
         $operationResponse->reload();
+
+        // Test operationStatusMethod and operationStatusDoneValue
+        $this->assertTrue($operationResponse->isDone());
+
+        $this->assertTrue($operationResponse->operationSucceeded());
 
         // test cancelOperationMethod
         $operationResponse->cancel();

--- a/tests/Unit/testdata/src/CustomOperationClient.php
+++ b/tests/Unit/testdata/src/CustomOperationClient.php
@@ -27,7 +27,7 @@ abstract class BaseOperationRequest
     public string $arg2;
     public string $arg3;
 
-    public static function build(string $name, string $arg2, string $arg3): static
+    public static function build(string $arg2, string $arg3, string $name): static
     {
         $request = new static();
         $request->name = $name;


### PR DESCRIPTION
fixes https://github.com/googleapis/gax-php/issues/565