### PR TITLE
feat: Add the rpcName to the BIDI stream opening request

### DIFF
--- a/src/Testing/MockGrpcTransport.php
+++ b/src/Testing/MockGrpcTransport.php
@@ -34,6 +34,7 @@ namespace Google\ApiCore\Testing;
 
 use Google\ApiCore\Transport\GrpcTransport;
 use Grpc\ChannelCredentials;
+use Psr\Log\LoggerInterface;
 
 /**
  * @internal
@@ -46,11 +47,11 @@ class MockGrpcTransport extends GrpcTransport
     /**
      * @param mixed $mockCall
      */
-    public function __construct($mockCall = null)
+    public function __construct($mockCall = null, ?LoggerInterface $logger = null)
     {
         $this->mockCall = $mockCall;
         $opts = ['credentials' => ChannelCredentials::createSsl()];
-        parent::__construct('', $opts);
+        parent::__construct('', $opts, logger: $logger);
     }
 
     /**

--- a/src/Transport/GrpcTransport.php
+++ b/src/Transport/GrpcTransport.php
@@ -178,7 +178,7 @@ class GrpcTransport extends BaseStub implements TransportInterface
     {
         $this->verifyUniverseDomain($options);
 
-        return new BidiStream(
+        $bidiStream = new BidiStream(
             $this->_bidiRequest(
                 '/' . $call->getMethod(),
                 [$call->getDecodeType(), 'decode'],
@@ -188,6 +188,21 @@ class GrpcTransport extends BaseStub implements TransportInterface
             $call->getDescriptor(),
             $this->logger
         );
+
+        if ($this->logger) {
+            $requestEvent = new RpcLogEvent();
+
+            $requestEvent->headers = $options['headers'];
+            $requestEvent->retryAttempt = $options['retryAttempt'] ?? null;
+            $requestEvent->serviceName = $options['serviceName'] ?? null;
+            $requestEvent->rpcName = $call->getMethod();
+            $requestEvent->processId = (int) getmypid();
+            $requestEvent->requestId = crc32((string) spl_object_id($bidiStream) . getmypid());
+
+            $this->logRequest($requestEvent);
+        }
+
+        return $bidiStream;
     }
 
     /**


### PR DESCRIPTION
This PR adds the `rpcName` field to the logs when opening a BIDI stream.