### PR TITLE
chore: deprecate using string or array credentials

### DIFF
--- a/src/Options/ClientOptions.php
+++ b/src/Options/ClientOptions.php
@@ -112,19 +112,19 @@ class ClientOptions implements ArrayAccess, OptionsInterface
      *           path to a JSON file, or a PHP array containing the decoded JSON data.
      *           By default this settings points to the default client config file, which is provided
      *           in the resources folder.
-     *     @type string|array|FetchAuthTokenInterface|CredentialsWrapper $credentials
-     *           The credentials to be used by the client to authorize API calls. This option
-     *           accepts either a path to a credentials file, or a decoded credentials file as a
-     *           PHP array.
-     *           *Advanced usage*: In addition, this option can also accept a pre-constructed
-     *           \Google\Auth\FetchAuthTokenInterface object or \Google\ApiCore\CredentialsWrapper
-     *           object. Note that when one of these objects are provided, any settings in
-     *           $authConfig will be ignored.
-     *           *Important*: If you accept a credential configuration (credential JSON/File/Stream)
-     *           from an external source for authentication to Google Cloud Platform, you must
-     *           validate it before providing it to any Google API or library. Providing an
-     *           unvalidated credential configuration to Google APIs can compromise the security of
-     *           your systems and data. For more information
+     *     @type FetchAuthTokenInterface|CredentialsWrapper $credentials
+     *           This option should only be used with a pre-constructed \Google\Auth\FetchAuthTokenInterface
+     *           object or \Google\ApiCore\CredentialsWrapper object. Note that when one of these objects
+     *           are provided, any settings in $authConfig will be ignored.
+     *           **Important**: If you are providing a path to a credentials file, or a decoded credentials
+     *           file as a PHP array, this usage is now DEPRECATED. Providing an unvalidated credential
+     *           configuration to Google APIs can compromise the security of your systems and data. It is now
+     *           recommended to create the credentials explicitly:
+     *           ```
+     *           $creds = new Google\Auth\Credentials\ServiceAccountCredentials($scopes, $json);
+     *           $options = new Google\ApiCore\Options\ClientOptions(['credentials' => $creds]);
+     *           ```
+     *           For more information
      *           {@see https://cloud.google.com/docs/authentication/external/externally-sourced-credentials}
      *     @type array $credentialsConfig
      *           Options used to configure credentials, including auth token caching, for the client.


### PR DESCRIPTION
See https://github.com/googleapis/google-auth-library-php/pull/624 where this was done in the `google/auth` library