### PR TITLE
Add GOOGLE_API_TRANSPORT environment variable support

### DIFF
--- a/src/ClientOptionsTrait.php
+++ b/src/ClientOptionsTrait.php
@@ -124,6 +124,14 @@ trait ClientOptionsTrait
             'logger' => null,
         ];
 
+        // Check for transport method in environment variable if not set in options
+        if (!isset($options['transport'])) {
+            $envTransport = getenv('GOOGLE_API_TRANSPORT');
+            if ($envTransport !== false && in_array($envTransport, ['rest', 'grpc', 'grpc-fallback'])) {
+                $options['transport'] = $envTransport;
+            }
+        }
+
         $supportedTransports = $this->supportedTransports();
         foreach ($supportedTransports as $transportName) {
             if (!array_key_exists($transportName, $defaultOptions['transportConfig'])) {


### PR DESCRIPTION
This PR adds support for configuring the transport method via the `GOOGLE_API_TRANSPORT` environment variable, allowing users to set the transport to rest, grpc, or grpc-fallback at the environment level.

#  Problem

Currently, the transport method must be manually configured for each Google Cloud PHP client library implementation by passing `['transport' => 'rest']` in the options array. This approach presents several challenges:

- When managing multiple client libraries across an application, developers must remember to set the transport option for each individual client instantiation.
- The same transport configuration must be repeated throughout the codebase.

# Solution

This PR introduces the `GOOGLE_API_TRANSPORT` environment variable that allows setting the transport method globally. 

# Usage

```
GOOGLE_API_TRANSPORT=rest php my-script.php
```