### PR TITLE
fix: add return type to `offsetGet`

### DIFF
--- a/src/Options/OptionsTrait.php
+++ b/src/Options/OptionsTrait.php
@@ -57,6 +57,9 @@ trait OptionsTrait
         return isset($this->$offset);
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {


### PR DESCRIPTION
Fixes deprecation warning:

> `User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Google\ApiCore\Options\ClientOptions" now to avoid errors or add an explicit @return annotation to suppress this message.`