### PR TITLE
Feat: Add the PrependMiddleware method

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -702,7 +702,7 @@ trait GapicClientTrait
             return $this->transport->$startCallMethod($call, $options);
         };
 
-        foreach (\array_reverse($this->prependMiddlewareCallables) as $fn) {
+        foreach ($this->prependMiddlewareCallables as $fn) {
             /** @var MiddlewareInterface $callStack */
             $callStack = $fn($callStack);
         }

--- a/tests/Unit/GapicClientTraitTest.php
+++ b/tests/Unit/GapicClientTraitTest.php
@@ -1463,6 +1463,76 @@ class GapicClientTraitTest extends TestCase
         $this->assertEquals(['middleware1', 'middleware2'], $callOrder);
     }
 
+     public function testPrependMiddlewareOrder()
+    {
+        list($client, $transport) = $this->buildClientToTestModifyCallMethods();
+
+        $callOrder = [];
+        $middleware1 = function (callable $handler) use (&$callOrder) {
+            return new class($handler, $callOrder) implements MiddlewareInterface {
+                private $handler;
+                private array $callOrder;
+                public function __construct(
+                    callable $handler,
+                    array &$callOrder
+                ) {
+                    $this->handler = $handler;
+                    $this->callOrder = &$callOrder;
+                }
+                public function __invoke(Call $call, array $options)
+                {
+                    $this->callOrder[] = 'middleware1';
+                    return ($this->handler)($call, $options);
+                }
+            };
+        };
+        $middleware2 = function (callable $handler) use (&$callOrder) {
+            return new class($handler, $callOrder) implements MiddlewareInterface {
+                private $handler;
+                private array $callOrder;
+                public function __construct(
+                    callable $handler,
+                    array &$callOrder
+                ) {
+                    $this->handler = $handler;
+                    $this->callOrder = &$callOrder;
+                }
+                public function __invoke(Call $call, array $options)
+                {
+                    $this->callOrder[] = 'middleware2';
+                    return ($this->handler)($call, $options);
+                }
+            };
+        };
+
+        $client->prependMiddleware($middleware1);
+        $client->prependMiddleware($middleware2);
+
+        $transport->startUnaryCall(
+            Argument::type(Call::class),
+            [
+                'transportOptions' => [
+                    'custom' => ['addModifyUnaryCallableOption' => true]
+                ],
+                'headers' => AgentHeader::buildAgentHeader([]),
+                'credentialsWrapper' => CredentialsWrapper::build([
+                    'keyFile' => __DIR__ . '/testdata/json-key-file.json'
+                ])
+            ]
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn(new FulfilledPromise(new Operation()));
+
+        $client->startCall(
+            'simpleMethod',
+            'decodeType',
+            [],
+            new MockRequest(),
+        )->wait();
+
+        $this->assertEquals(['middleware2', 'middleware1'], $callOrder);
+    }
+
     public function testInvalidClientOptionsTypeThrowsExceptionForV2SurfaceOnly()
     {
         // v1 client


### PR DESCRIPTION
Added a new Method to the GapicClientTrait: PrependMiddleware.

This method lets the user add a middleware that executes at the end of the callstack of middleware instead that exclusively at the beginning.