### PR TITLE
fix: Use self:: instead of $this-> for static validation methods in GapicClientTrait validation 

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -261,7 +261,7 @@ trait GapicClientTrait
         if (isset($options['serviceAddress'])) {
             $options['apiEndpoint'] = $this->pluck('serviceAddress', $options, false);
         }
-        $this->validateNotNull($options, [
+        self::validateNotNull($options, [
             'apiEndpoint',
             'serviceName',
             'descriptorsConfigPath',
@@ -270,7 +270,7 @@ trait GapicClientTrait
             'credentialsConfig',
             'transportConfig',
         ]);
-        $this->traitValidate($options, [
+        self::traitValidate($options, [
             'credentials',
             'transport',
             'gapicVersion',


### PR DESCRIPTION
This PR fixes a critical issue where enabling OpCache (specifically with JIT or strict optimization levels) causes a fatal error: `Too few arguments to function `Google\Cloud...\GapicClientTrait::validateNotNull()`, 2 passed ... and exactly 2 expected`

The methods `validateNotNull` and `traitValidate` (aliased from `ValidationTrait::validate`) are defined as static. However, they are currently called using instance syntax (`$this->...`).

While valid in standard PHP, some OpCache/JIT configurations misinterpret the stack frame when a static method is invoked via `$this`, potentially counting the implicit object instance as a misaligned argument or failing to discard it correctly before the static call.

I have updated the calls to use `self::` instead of `$this->`. 
This explicitly invokes them as static methods, ensuring the correct opcode generation and preventing the argument count mismatch error in optimized environments.

closes #642


what is this code? 
opening it in an IDE is like a Christmas tree 
```
'str*()' calls can be replaced with PHP 8 'str_*()' calls
::class constant usage correctness
Callable parameter usage violates definition
Deprecated
Fully qualified name usage
Grammar
Incompatible return type
JSON encoding API usage
Missing @throws tag(s)
Missing parameter's type declaration
Missing return type declaration
Missing strict types declaration
Nested positive ifs
Null reference
One-time use variables
PHPDoc comment matches function/method signature
PHPDoc comment signature is not complete
Possible polymorphic call
Referencing objects
Return type hint can be used
Return type in PHPDoc comment does not match the actual return type
Spelling
Type unsafe comparison
Undefined class
Unhandled exception
Unnecessary fully qualified name
Unqualified function/constant reference
```