### PR TITLE
fix(serializer): catch Throwable to handle PHP 7+ Errors

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -252,7 +252,7 @@ class Serializer
                 /** @var Message $unpacked */
                 $unpacked = $any->unpack();
                 $results[] = self::serializeToPhpArray($unpacked);
-            } catch (\Exception $ex) {
+            } catch (\Throwable $ex) {
                 // failed to unpack the $any object - show as unknown binary data
                 $results[] = [
                     'typeUrl' => $any->getTypeUrl(),


### PR DESCRIPTION
PHP7+ introduced the following hierarchy: https://www.php.net/manual/en/language.errors.php7.php

There's a base Throwable class which both Error and Exception derive from.

When using the protobuf.so C extension, it's possible that an error message such as "Class zetasql.ErrorMessageModeForPayload hasn't been added to descriptor pool" can manifest as a TypeError or Error which don't derive from Exception and thus cause a fatal instead of being caught.