### PR TITLE
fix(rest): normalize generated REST HTTP methods

### DIFF
--- a/src/RequestBuilder.php
+++ b/src/RequestBuilder.php
@@ -117,7 +117,7 @@ class RequestBuilder
                 $uri = $this->buildUri($pathTemplate, $queryParams);
 
                 return new Request(
-                    $config['method'],
+                    strtoupper($config['method']),
                     $uri,
                     ['Content-Type' => 'application/json'] + $headers,
                     $body

--- a/tests/Unit/RequestBuilderTest.php
+++ b/tests/Unit/RequestBuilderTest.php
@@ -63,6 +63,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertSame('https', $uri->getScheme());
+        $this->assertSame('GET', $request->getMethod());
         $this->assertEmpty($uri->getQuery());
         $this->assertEmpty((string) $request->getBody());
         $this->assertSame('/v1/message/foo', $uri->getPath());
@@ -80,6 +81,7 @@ class RequestBuilderTest extends TestCase
         $uri = $request->getUri();
 
         $this->assertSame('https', $uri->getScheme());
+        $this->assertSame('POST', $request->getMethod());
         $this->assertEmpty($uri->getQuery());
         $this->assertSame('/v1/message/foo', $uri->getPath());
         $this->assertEquals(


### PR DESCRIPTION
Hi there. The Guzzle maintainer here again. I am working on the next major version of Guzzle with a focus on security hardening and reducing security-foot guns. As part of these changes, I am better aligning with spec compliance and our request class will no longer automatically uppercase the verb (because verbs are case-sensitive). I've not yet decided if I want to raise deprecation warnings in the current series about this, but if I do, this PR should mitigate that for you. If not, then you are forwards compatible with the next release too.