### PR TITLE
feat: Add a new filter option to the OptionsFilterMiddleware

### DIFF
--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -700,18 +700,8 @@ trait GapicClientTrait
 
         $callStack = new TransportCallMiddleware($this->transport, $this->transportCallMethods);
 
-        foreach ($this->prependMiddlewareCallables as $fn) {
-            /** @var MiddlewareInterface $callStack */
-            $callStack = $fn($callStack);
-        }
-
         $callStack = new CredentialsWrapperMiddleware($callStack, $this->credentialsWrapper);
-        $callStack = new FixedHeaderMiddleware($callStack, $fixedHeaders, true);
-        $callStack = new RetryMiddleware($callStack, $callConstructionOptions['retrySettings']);
-        $callStack = new RequestAutoPopulationMiddleware(
-            $callStack,
-            $callConstructionOptions['autoPopulationSettings'],
-        );
+
         $callStack = new OptionsFilterMiddleware($callStack, [
             'headers',
             'timeoutMillis',
@@ -720,6 +710,18 @@ trait GapicClientTrait
             'audience',
             'metadataReturnType'
         ]);
+
+        foreach ($this->prependMiddlewareCallables as $fn) {
+            /** @var MiddlewareInterface $callStack */
+            $callStack = $fn($callStack);
+        }
+
+        $callStack = new FixedHeaderMiddleware($callStack, $fixedHeaders, true);
+        $callStack = new RetryMiddleware($callStack, $callConstructionOptions['retrySettings']);
+        $callStack = new RequestAutoPopulationMiddleware(
+            $callStack,
+            $callConstructionOptions['autoPopulationSettings'],
+        );
 
         foreach (\array_reverse($this->middlewareCallables) as $fn) {
             /** @var MiddlewareInterface $callStack */

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -700,15 +700,14 @@ trait GapicClientTrait
 
         $callStack = new TransportCallMiddleware($this->transport, $this->transportCallMethods);
 
-        $callStack = new CredentialsWrapperMiddleware($callStack, $this->credentialsWrapper);
-
         $callStack = new OptionsFilterMiddleware($callStack, [
             'headers',
             'timeoutMillis',
             'transportOptions',
             'metadataCallback',
             'audience',
-            'metadataReturnType'
+            'metadataReturnType',
+            'credentialsWrapper'
         ]);
 
         foreach ($this->prependMiddlewareCallables as $fn) {
@@ -716,6 +715,7 @@ trait GapicClientTrait
             $callStack = $fn($callStack);
         }
 
+        $callStack = new CredentialsWrapperMiddleware($callStack, $this->credentialsWrapper);
         $callStack = new FixedHeaderMiddleware($callStack, $fixedHeaders, true);
         $callStack = new RetryMiddleware($callStack, $callConstructionOptions['retrySettings']);
         $callStack = new RequestAutoPopulationMiddleware(

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -700,16 +700,6 @@ trait GapicClientTrait
 
         $callStack = new TransportCallMiddleware($this->transport, $this->transportCallMethods);
 
-        $callStack = new OptionsFilterMiddleware($callStack, [
-            'headers',
-            'timeoutMillis',
-            'transportOptions',
-            'metadataCallback',
-            'audience',
-            'metadataReturnType',
-            'credentialsWrapper'
-        ]);
-
         foreach ($this->prependMiddlewareCallables as $fn) {
             /** @var MiddlewareInterface $callStack */
             $callStack = $fn($callStack);
@@ -722,6 +712,15 @@ trait GapicClientTrait
             $callStack,
             $callConstructionOptions['autoPopulationSettings'],
         );
+        $callStack = new OptionsFilterMiddleware($callStack, [
+            'headers',
+            'timeoutMillis',
+            'transportOptions',
+            'metadataCallback',
+            'audience',
+            'metadataReturnType',
+            'middlewareOptions'
+        ]);
 
         foreach (\array_reverse($this->middlewareCallables) as $fn) {
             /** @var MiddlewareInterface $callStack */

--- a/tests/Unit/GapicClientTraitTest.php
+++ b/tests/Unit/GapicClientTraitTest.php
@@ -135,7 +135,7 @@ class GapicClientTraitTest extends TestCase
         );
     }
 
-    public function testPrependedMiddlewareCanSeeCallOptionAddedByAppendedMiddleware()
+    public function testMiddlewareOptionsIsPreservedByFilterAndVisibleToMiddlewares()
     {
         $unaryDescriptors = [
             'callType' => Call::UNARY_CALL,
@@ -144,9 +144,14 @@ class GapicClientTraitTest extends TestCase
         $request = new MockRequestBody([]);
         $transport = $this->prophesize(TransportInterface::class);
 
+        $middlewareOptions = ['myCustomKey' => 'myCustomValue'];
+
         $transport->startUnaryCall(
             Argument::type(Call::class),
-            Argument::any()
+            Argument::that(function ($options) use ($middlewareOptions) {
+                return isset($options['middlewareOptions'])
+                    && $options['middlewareOptions'] === $middlewareOptions;
+            })
         )
             ->shouldBeCalledOnce()
             ->willReturn($this->prophesize(PromiseInterface::class)->reveal());
@@ -165,80 +170,32 @@ class GapicClientTraitTest extends TestCase
         $client->set('credentialsWrapper', $credentialsWrapper);
         $client->set('descriptors', ['method' => $unaryDescriptors]);
 
-        // 1. Append a middleware (outermost) that adds a custom option to callOptions
-        $client->addMiddleware(function (callable $handler) {
-            return function (Call $call, array $options) use ($handler) {
-                $options['myCustomOption'] = 'myCustomValue';
+        $appendedCalled = false;
+        $client->addMiddleware(function (callable $handler) use (&$appendedCalled, $middlewareOptions) {
+            return function (Call $call, array $options) use ($handler, &$appendedCalled, $middlewareOptions) {
+                $appendedCalled = true;
+                $this->assertEquals($middlewareOptions, $options['middlewareOptions'] ?? null);
                 return $handler($call, $options);
             };
         });
 
-        // 2. Prepend a middleware (innermost) that confirms it can see the custom option
-        $prependedMiddlewareCalled = false;
-        $client->prependMiddleware(function (callable $handler) use (&$prependedMiddlewareCalled) {
-            return function (Call $call, array $options) use ($handler, &$prependedMiddlewareCalled) {
-                $prependedMiddlewareCalled = true;
-                $this->assertTrue(isset($options['myCustomOption']));
-                $this->assertEquals('myCustomValue', $options['myCustomOption']);
-                return $handler($call, $options);
-            };
-        });
-
-        $client->startApiCall(
-            'method',
-            $request
-        );
-
-        $this->assertTrue($prependedMiddlewareCalled);
-    }
-
-    public function testOptionsFilterMiddlewareAllowsCredentialsWrapperButStripsOtherCustomOptions()
-    {
-        $unaryDescriptors = [
-            'callType' => Call::UNARY_CALL,
-            'responseType' => 'decodeType'
-        ];
-        $request = new MockRequestBody([]);
-        $transport = $this->prophesize(TransportInterface::class);
-        
-        $customCredentialsWrapper = CredentialsWrapper::build([
-            'keyFile' => __DIR__ . '/testdata/json-key-file.json'
-        ]);
-
-        $transport->startUnaryCall(
-            Argument::type(Call::class),
-            Argument::that(function ($options) use ($customCredentialsWrapper) {
-                $hasCredentialsWrapper = isset($options['credentialsWrapper']) 
-                    && $options['credentialsWrapper'] === $customCredentialsWrapper;
-                $doesNotHaveCustomOption = !isset($options['myCustomOption']);
-                return $hasCredentialsWrapper && $doesNotHaveCustomOption;
-            })
-        )
-            ->shouldBeCalledOnce()
-            ->willReturn($this->prophesize(PromiseInterface::class)->reveal());
-
-        $client = new StubGapicClient();
-        $client->set('agentHeader', []);
-        $client->set(
-            'retrySettings',
-            ['method' => $this->prophesize(RetrySettings::class)->reveal()]
-        );
-        $client->set('transport', $transport->reveal());
-        $client->set('credentialsWrapper', $customCredentialsWrapper);
-        $client->set('descriptors', ['method' => $unaryDescriptors]);
-
-        $client->addMiddleware(function (callable $handler) use ($customCredentialsWrapper) {
-            return function (Call $call, array $options) use ($handler, $customCredentialsWrapper) {
-                $options['credentialsWrapper'] = $customCredentialsWrapper;
-                $options['myCustomOption'] = 'myCustomValue';
+        $prependedCalled = false;
+        $client->prependMiddleware(function (callable $handler) use (&$prependedCalled, $middlewareOptions) {
+            return function (Call $call, array $options) use ($handler, &$prependedCalled, $middlewareOptions) {
+                $prependedCalled = true;
+                $this->assertEquals($middlewareOptions, $options['middlewareOptions'] ?? null);
                 return $handler($call, $options);
             };
         });
 
         $client->startApiCall(
             'method',
-            $request
+            $request,
+            ['middlewareOptions' => $middlewareOptions]
         );
+
+        $this->assertTrue($appendedCalled, 'Appended middleware should have been called');
+        $this->assertTrue($prependedCalled, 'Prepended middleware should have been called');
     }
 
     public function testVersionedHeadersOverwriteBehavior()

--- a/tests/Unit/GapicClientTraitTest.php
+++ b/tests/Unit/GapicClientTraitTest.php
@@ -135,6 +135,112 @@ class GapicClientTraitTest extends TestCase
         );
     }
 
+    public function testPrependedMiddlewareCanSeeCallOptionAddedByAppendedMiddleware()
+    {
+        $unaryDescriptors = [
+            'callType' => Call::UNARY_CALL,
+            'responseType' => 'decodeType'
+        ];
+        $request = new MockRequestBody([]);
+        $transport = $this->prophesize(TransportInterface::class);
+
+        $transport->startUnaryCall(
+            Argument::type(Call::class),
+            Argument::any()
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($this->prophesize(PromiseInterface::class)->reveal());
+
+        $credentialsWrapper = CredentialsWrapper::build([
+            'keyFile' => __DIR__ . '/testdata/json-key-file.json'
+        ]);
+
+        $client = new StubGapicClient();
+        $client->set('agentHeader', []);
+        $client->set(
+            'retrySettings',
+            ['method' => $this->prophesize(RetrySettings::class)->reveal()]
+        );
+        $client->set('transport', $transport->reveal());
+        $client->set('credentialsWrapper', $credentialsWrapper);
+        $client->set('descriptors', ['method' => $unaryDescriptors]);
+
+        // 1. Append a middleware (outermost) that adds a custom option to callOptions
+        $client->addMiddleware(function (callable $handler) {
+            return function (Call $call, array $options) use ($handler) {
+                $options['myCustomOption'] = 'myCustomValue';
+                return $handler($call, $options);
+            };
+        });
+
+        // 2. Prepend a middleware (innermost) that confirms it can see the custom option
+        $prependedMiddlewareCalled = false;
+        $client->prependMiddleware(function (callable $handler) use (&$prependedMiddlewareCalled) {
+            return function (Call $call, array $options) use ($handler, &$prependedMiddlewareCalled) {
+                $prependedMiddlewareCalled = true;
+                $this->assertTrue(isset($options['myCustomOption']));
+                $this->assertEquals('myCustomValue', $options['myCustomOption']);
+                return $handler($call, $options);
+            };
+        });
+
+        $client->startApiCall(
+            'method',
+            $request
+        );
+
+        $this->assertTrue($prependedMiddlewareCalled);
+    }
+
+    public function testOptionsFilterMiddlewareAllowsCredentialsWrapperButStripsOtherCustomOptions()
+    {
+        $unaryDescriptors = [
+            'callType' => Call::UNARY_CALL,
+            'responseType' => 'decodeType'
+        ];
+        $request = new MockRequestBody([]);
+        $transport = $this->prophesize(TransportInterface::class);
+        
+        $customCredentialsWrapper = CredentialsWrapper::build([
+            'keyFile' => __DIR__ . '/testdata/json-key-file.json'
+        ]);
+
+        $transport->startUnaryCall(
+            Argument::type(Call::class),
+            Argument::that(function ($options) use ($customCredentialsWrapper) {
+                $hasCredentialsWrapper = isset($options['credentialsWrapper']) 
+                    && $options['credentialsWrapper'] === $customCredentialsWrapper;
+                $doesNotHaveCustomOption = !isset($options['myCustomOption']);
+                return $hasCredentialsWrapper && $doesNotHaveCustomOption;
+            })
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($this->prophesize(PromiseInterface::class)->reveal());
+
+        $client = new StubGapicClient();
+        $client->set('agentHeader', []);
+        $client->set(
+            'retrySettings',
+            ['method' => $this->prophesize(RetrySettings::class)->reveal()]
+        );
+        $client->set('transport', $transport->reveal());
+        $client->set('credentialsWrapper', $customCredentialsWrapper);
+        $client->set('descriptors', ['method' => $unaryDescriptors]);
+
+        $client->addMiddleware(function (callable $handler) use ($customCredentialsWrapper) {
+            return function (Call $call, array $options) use ($handler, $customCredentialsWrapper) {
+                $options['credentialsWrapper'] = $customCredentialsWrapper;
+                $options['myCustomOption'] = 'myCustomValue';
+                return $handler($call, $options);
+            };
+        });
+
+        $client->startApiCall(
+            'method',
+            $request
+        );
+    }
+
     public function testVersionedHeadersOverwriteBehavior()
     {
         $unaryDescriptors = [


### PR DESCRIPTION
Added a new filter option for the OptionsFilterMiddleware allowing the `middlewareOptions` option to be passed around multiple middleware for communication.