### PR TITLE
feat: add support for Regional Access Boundaries in auth

### DIFF
--- a/src/CredentialsWrapper.php
+++ b/src/CredentialsWrapper.php
@@ -58,7 +58,6 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
     /** @var callable $authHttpHandle */
     private $authHttpHandler;
 
-    private string $universeDomain;
     private bool $hasCheckedUniverse = false;
 
     /** @var int */
@@ -76,14 +75,13 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
     public function __construct(
         FetchAuthTokenInterface $credentialsFetcher,
         ?callable $authHttpHandler = null,
-        string $universeDomain = GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN
+        private string $universeDomain = GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
     ) {
         $this->credentialsFetcher = $credentialsFetcher;
         $this->authHttpHandler = $authHttpHandler;
         if (empty($universeDomain)) {
             throw new ValidationException('The universe domain cannot be empty');
         }
-        $this->universeDomain = $universeDomain;
     }
 
     /**
@@ -116,6 +114,9 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
      *     @type bool $useJwtAccessWithScope
      *           Ensures service account credentials use JWT Access (also known as self-signed
      *           JWTs), even when user-defined scopes are supplied.
+     *     @type bool $enableRegionalAccessBoundary
+     *           Enable the Regional Access Boundary lookup in the credentials which sets the
+     *           `x-allowed-locations` header in the request.
      * }
      * @param string $universeDomain The expected universe of the credentials. Defaults to
      *                               "googleapis.com"
@@ -136,6 +137,7 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
             'quotaProject'      => null,
             'defaultScopes'     => null,
             'useJwtAccessWithScope' => true,
+            'enableRegionalAccessBoundary' => false,
         ];
 
         $keyFile = $args['keyFile'];
@@ -147,7 +149,8 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
                 $args['authCacheOptions'],
                 $args['authCache'],
                 $args['quotaProject'],
-                $args['defaultScopes']
+                $args['defaultScopes'],
+                $args['enableRegionalAccessBoundary'],
             );
             if ($loader instanceof FetchAuthTokenCache) {
                 $loader = $loader->getFetcher();
@@ -167,7 +170,8 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
             $loader = CredentialsLoader::makeCredentials(
                 $args['scopes'],
                 $keyFile,
-                $args['defaultScopes']
+                $args['defaultScopes'],
+                $args['enableRegionalAccessBoundary'],
             );
         }
 
@@ -322,7 +326,8 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
         ?array $authCacheOptions = null,
         ?CacheItemPoolInterface $authCache = null,
         $quotaProject = null,
-        ?array $defaultScopes = null
+        ?array $defaultScopes = null,
+        bool $enableRegionalAccessBoundary = true,
     ) {
         try {
             return ApplicationDefaultCredentials::getCredentials(
@@ -331,7 +336,10 @@ class CredentialsWrapper implements HeaderCredentialsInterface, ProjectIdProvide
                 $authCacheOptions,
                 $authCache,
                 $quotaProject,
-                $defaultScopes
+                $defaultScopes,
+                null, // $universeDomain
+                null, // $logger
+                $enableRegionalAccessBoundary,
             );
         } catch (DomainException $ex) {
             throw new ValidationException('Could not construct ApplicationDefaultCredentials', $ex->getCode(), $ex);

--- a/src/GapicClientTrait.php
+++ b/src/GapicClientTrait.php
@@ -344,10 +344,18 @@ trait GapicClientTrait
                 $options['credentialsConfig']['quotaProject'] ?? null
             );
         } else {
+            $enableRegionalAccessBoundary = filter_var(
+                getenv('GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT'),
+                FILTER_VALIDATE_BOOLEAN
+            );
+            $isRegional = str_ends_with($options['apiEndpoint'], '.rep.googleapis.com')
+                || str_ends_with($options['apiEndpoint'], '.rep.sandbox.googleapis.com');
             $this->credentialsWrapper = $this->createCredentialsWrapper(
                 $options['credentials'],
-                $options['credentialsConfig'],
-                $options['universeDomain']
+                $options['credentialsConfig'] + [
+                    'enableRegionalAccessBoundary' => $enableRegionalAccessBoundary && !$isRegional
+                ],
+                $options['universeDomain'],
             );
         }
 

--- a/tests/Unit/CredentialsWrapperTest.php
+++ b/tests/Unit/CredentialsWrapperTest.php
@@ -121,6 +121,34 @@ class CredentialsWrapperTest extends TestCase
                 ['quotaProject' => $quotaProject],
                 new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(null, $authHttpHandler, null, $defaultAuthCache, $quotaProject)),
             ],
+            [
+                ['enableRegionalAccessBoundary' => true],
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(
+                    null,
+                    $authHttpHandler,
+                    null,
+                    $defaultAuthCache,
+                    null,
+                    null,
+                    null,
+                    null,
+                    true, // $enableRegionalAccessBoundary
+                )),
+            ],
+            [
+                ['enableRegionalAccessBoundary' => false],
+                new CredentialsWrapper(ApplicationDefaultCredentials::getCredentials(
+                    null,
+                    $authHttpHandler,
+                    null,
+                    $defaultAuthCache,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false, // $enableRegionalAccessBoundary
+                )),
+            ],
         ];
 
         $this->setEnv('GOOGLE_APPLICATION_CREDENTIALS', $appDefaultCreds);

--- a/tests/Unit/GapicClientTraitTest.php
+++ b/tests/Unit/GapicClientTraitTest.php
@@ -890,6 +890,51 @@ class GapicClientTraitTest extends TestCase
     }
 
     /**
+     * @dataProvider buildClientOptionsRegionalEndpointData
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testBuildClientOptionsRegionalEndpoint(?string $apiEndpoint, ?string $envVarValue, bool $rabEnabled)
+    {
+        if ($envVarValue !== null) {
+            putenv('GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT=' . $envVarValue);
+        }
+
+        $client = new class() extends StubGapicClient {
+            public array $capturedCredentialsConfig = [];
+
+            public function createCredentialsWrapper($credentials, array $credentialsConfig, string $universeDomain)
+            {
+                $this->capturedCredentialsConfig = $credentialsConfig;
+                return null;
+            }
+        };
+
+        $clientOptions = $client->buildClientOptions(
+            $apiEndpoint !== null ? ['apiEndpoint' => $apiEndpoint] : []
+        );
+        $client->setClientOptions($clientOptions);
+
+        $this->assertEquals(
+            $rabEnabled,
+            $client->capturedCredentialsConfig['enableRegionalAccessBoundary'] ?? null
+        );
+    }
+
+    public function buildClientOptionsRegionalEndpointData()
+    {
+        return [
+            ['test.googleapis.com', 'true', true],
+            ['test.rep.googleapis.com', 'true', false],
+            ['test.rep.sandbox.googleapis.com', 'true', false],
+            ['test.googleapis.com', 'false', false],
+            ['test.googleapis.com', null, false],
+            ['', 'true', true], // Empty endpoint case
+            [null, 'true', true], // Unset endpoint case
+        ];
+    }
+
+    /**
      * @dataProvider buildRequestHeaderParams
      */
     public function testBuildRequestHeaders($headerParams, $request, $expected)


### PR DESCRIPTION
add support for https://github.com/googleapis/google-auth-library-php/pull/649 in Auth

 - Behind `GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT` environment variable flag for now. To enable, set this variable to `true`